### PR TITLE
Fix file download, announcements crash, and dropbox feedback

### DIFF
--- a/src/tools/download-file.ts
+++ b/src/tools/download-file.ts
@@ -105,6 +105,33 @@ export function registerDownloadFile(
 }
 
 /**
+ * Extract a filename from a Content-Disposition header.
+ */
+export function parseContentDispositionFilename(
+  disposition: string
+): string | null {
+  const extended = disposition.match(/filename\*\s*=\s*([^;]+)/i);
+  if (extended?.[1]) {
+    const value = extended[1].trim();
+    const parts = value.split("'");
+    const encoded = parts.length >= 3 ? parts.slice(2).join("'") : value;
+    try {
+      return decodeURIComponent(encoded);
+    } catch {
+      return encoded;
+    }
+  }
+
+  const plain = disposition.match(/filename\s*=\s*("([^"]*)"|[^;\n]*)/i);
+  if (plain) {
+    const value = (plain[2] ?? plain[1] ?? "").trim();
+    if (value) return value;
+  }
+
+  return null;
+}
+
+/**
  * Download a content file using topicId
  */
 async function downloadContentFile(
@@ -138,11 +165,7 @@ async function downloadContentFile(
 
   // Get filename from Content-Disposition header
   const disposition = response.headers.get("Content-Disposition") ?? "";
-  let filename = "download";
-  const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
-  if (match?.[1]) {
-    filename = match[1].replace(/['"]/g, "");
-  }
+  const filename = parseContentDispositionFilename(disposition) ?? "download";
 
   log("DEBUG", `Content-Disposition filename: ${filename}`);
 

--- a/src/tools/get-announcements.ts
+++ b/src/tools/get-announcements.ts
@@ -17,8 +17,8 @@ import type { AppConfig } from "../types/index.js";
 interface NewsItem {
   Id: number;
   Title: string;
-  Body: { Text: string; Html: string };
-  CreatedBy: { Identifier: string; DisplayName: string };
+  Body: { Text: string; Html: string } | null;
+  CreatedBy: { Identifier: string; DisplayName: string } | null;
   CreatedDate: string;
   LastModifiedBy: { Identifier: string; DisplayName: string };
   LastModifiedDate: string;
@@ -48,6 +48,21 @@ interface EnrollmentResponse {
   PagingInfo?: {
     HasMoreItems: boolean;
     Bookmark?: string;
+  };
+}
+
+/**
+ * Map a raw D2L news item to a clean announcement object.
+ */
+export function mapNewsItem(item: NewsItem) {
+  return {
+    id: item.Id,
+    title: item.Title,
+    body: item.Body?.Text ?? "",
+    createdBy: item.CreatedBy?.DisplayName ?? "Unknown",
+    createdDate: item.CreatedDate,
+    startDate: item.StartDate,
+    isPinned: item.IsPinned,
   };
 }
 
@@ -83,15 +98,7 @@ export function registerGetAnnouncements(
 
           // Map to clean objects
           const announcements = newsItems
-            .map((item) => ({
-              id: item.Id,
-              title: item.Title,
-              body: item.Body.Text,
-              createdBy: item.CreatedBy.DisplayName,
-              createdDate: item.CreatedDate,
-              startDate: item.StartDate,
-              isPinned: item.IsPinned,
-            }))
+            .map(mapNewsItem)
             .sort(
               (a, b) =>
                 new Date(b.createdDate).getTime() -
@@ -138,13 +145,7 @@ export function registerGetAnnouncements(
               });
 
               return newsItems.map((newsItem) => ({
-                id: newsItem.Id,
-                title: newsItem.Title,
-                body: newsItem.Body.Text,
-                createdBy: newsItem.CreatedBy.DisplayName,
-                createdDate: newsItem.CreatedDate,
-                startDate: newsItem.StartDate,
-                isPinned: newsItem.IsPinned,
+                ...mapNewsItem(newsItem),
                 courseId: item.OrgUnit.Id,
                 courseName: item.OrgUnit.Name,
               }));

--- a/src/tools/get-assignments.ts
+++ b/src/tools/get-assignments.ts
@@ -108,7 +108,7 @@ interface EnrollmentResponse {
 /**
  * Fetch assignments (dropbox + quizzes) for a single course
  */
-async function fetchCourseAssignments(
+export async function fetchCourseAssignments(
   apiClient: D2LApiClient,
   courseId: number
 ): Promise<any[]> {
@@ -151,19 +151,17 @@ async function fetchCourseAssignments(
         }
       }
 
-      // Fetch feedback if submissions exist
+      // Fetch feedback independently of submissions
       let feedback: DropboxFeedback | null = null;
-      if (submissions.length > 0) {
-        try {
-          feedback = await apiClient.get<DropboxFeedback>(
-            apiClient.le(courseId, `/dropbox/folders/${folder.Id}/feedback/myFeedback/`),
-            { ttl: DEFAULT_CACHE_TTLS.assignments }
-          );
-        } catch (error: any) {
-          // 404/403 means no feedback available - that's fine
-          if (error?.status !== 404 && error?.status !== 403) {
-            log("DEBUG", `Failed to fetch feedback for folder ${folder.Id}`, error);
-          }
+      try {
+        feedback = await apiClient.get<DropboxFeedback>(
+          apiClient.le(courseId, `/dropbox/folders/${folder.Id}/feedback/myFeedback/`),
+          { ttl: DEFAULT_CACHE_TTLS.assignments }
+        );
+      } catch (error: any) {
+        // 404/403 means no feedback available (or no access) - that's fine
+        if (error?.status !== 404 && error?.status !== 403) {
+          log("DEBUG", `Failed to fetch feedback for folder ${folder.Id}`, error);
         }
       }
 

--- a/src/utils/file-validator.ts
+++ b/src/utils/file-validator.ts
@@ -110,17 +110,28 @@ export async function validateFileType(
     return { mime: detected.mime, ext: detected.ext };
   }
 
-  // Fallback for text files that file-type can't detect
-  // Check if buffer looks like text (no null bytes, mostly printable chars)
-  const isText =
-    !buffer.includes(0) && buffer.toString("utf8", 0, 512).match(/^[\x20-\x7E\n\r\t]*$/);
+  // Fallback for text-based files with no magic-byte signature: accept if the
+  // buffer decodes as UTF-8 (rejecting binaries and NUL bytes), then sniff HTML.
+  if (!buffer.includes(0)) {
+    let decoded: string | null = null;
+    try {
+      decoded = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+    } catch {
+      // Invalid UTF-8 — treat as binary.
+    }
 
-  if (isText) {
-    // Allow common text MIME types
-    const textTypes = allowedTypes.filter((t) => t.startsWith("text/"));
-    if (textTypes.length > 0) {
-      // Default to text/plain for undetectable text files
-      return { mime: "text/plain", ext: "txt" };
+    if (decoded !== null) {
+      const noBom =
+        decoded.charCodeAt(0) === 0xfeff ? decoded.slice(1) : decoded;
+      const head = noBom.trimStart().toLowerCase();
+      const isHtml =
+        head.startsWith("<!doctype html") || head.startsWith("<html");
+      const mime = isHtml ? "text/html" : "text/plain";
+      const ext = isHtml ? "html" : "txt";
+
+      if (allowedTypes.includes(mime)) {
+        return { mime, ext };
+      }
     }
   }
 


### PR DESCRIPTION
W mcp btw bro

## Summary

Fixes three bugs found while using the server against a live Brightspace
instance. The fixes are institution-agnostic — they harden null handling and
endpoint behavior that any deployment can hit.

## Fixes

### 1. File downloads fail on UTF-8 BOM / HTML content
`validateFileType`'s text fallback rejected any file whose decoded content
started with a UTF-8 BOM (`EF BB BF`), so downloads of UTF-8 text/HTML course
content (e.g. an HTML course schedule) threw "could not determine file type."
The fallback now decodes as UTF-8 (strict), strips a leading BOM, and sniffs
HTML so it maps to `text/html` instead of being misreported as plain text.
Also hardened Content-Disposition parsing to handle the RFC 5987
`filename*=UTF-8''...` extended form.

### 2. `get_announcements` crashes on null body or author
System-generated announcements can have a `null` `Body` or `CreatedBy`. The
mapper accessed `.Text` / `.DisplayName` directly and threw, taking down the
whole tool (and silently dropping the course from the all-courses view). Body
and author are now null-guarded (`""` / `"Unknown"`).

### 3. `get_assignments` hides released feedback
Feedback was only fetched when a submission was detected. Released grades live
on their own `myFeedback` endpoint and can exist even when `mysubmissions`
returns nothing (or 403s) for the student, so released scores were being
hidden. Feedback is now fetched independently of submission presence.

## Testing
`npm run build` passes.
