### PR TITLE
fix: wait for SAML redirect chain before deciding login is needed

### DIFF
--- a/src/auth/browser-auth.ts
+++ b/src/auth/browser-auth.ts
@@ -479,8 +479,24 @@ export class BrowserAuth {
         timeout: 30000,
       });
 
-      const currentUrl = page.url();
+      let currentUrl = page.url();
       log("DEBUG", `Current URL after navigation: ${currentUrl}`);
+
+      // Some institutions (e.g. USC) bounce through an extra SAML hop such as
+      // /d2l/lp/auth/login/samlLogin.d2l before landing on /d2l/home, even when the
+      // restored cookies are still valid. `domcontentloaded` can resolve mid-chain,
+      // so re-check once the redirects settle. Without this we misread a live session
+      // as logged-out and start an SSO flow that waits for a login form that never
+      // renders — which throws before the caller can persist session.json.
+      if (!currentUrl.includes("/d2l/home")) {
+        try {
+          await page.waitForURL(/\/d2l\/home/, { timeout: 15000 });
+          log("DEBUG", "Redirect chain settled on /d2l/home");
+        } catch {
+          // Never landed on /d2l/home — a real login is required.
+        }
+        currentUrl = page.url();
+      }
 
       // If we were redirected away from /d2l/home, login is required
       const needsLogin = !currentUrl.includes("/d2l/home");

--- a/tests/auth/browser-auth-navigate.test.ts
+++ b/tests/auth/browser-auth-navigate.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { BrowserAuth } from "../../src/auth/browser-auth.js";
+import type { AppConfig } from "../../src/types/index.js";
+
+/**
+ * Regression tests for navigateAndLogin()'s already-authenticated detection.
+ *
+ * Some institutions (USC, for example) redirect through an intermediate SAML hop
+ * such as /d2l/lp/auth/login/samlLogin.d2l before landing on /d2l/home, even when
+ * the restored cookies are still valid. page.goto(..., { waitUntil:
+ * "domcontentloaded" }) can resolve while the URL is still that intermediate hop,
+ * so reading page.url() immediately afterwards misreports a live session as
+ * logged-out and kicks off an SSO flow that waits forever for a login form.
+ */
+
+const BASE_URL = "https://brightspace.example.edu";
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    baseUrl: BASE_URL,
+    sessionDir: "/tmp/does-not-matter",
+    tokenTtl: 3600,
+    headless: true,
+    username: "student@example.edu",
+    password: "hunter2",
+    courseFilter: {} as AppConfig["courseFilter"],
+    ...overrides,
+  };
+}
+
+/**
+ * Fake Page that reproduces a multi-hop redirect: goto() settles on the SAML hop
+ * and only a subsequent waitForURL() observes the final /d2l/home landing.
+ */
+function makeRedirectingPage(hops: string[]) {
+  let current = hops[0];
+  let index = 0;
+  return {
+    goto: vi.fn(async () => {
+      current = hops[0];
+      return null;
+    }),
+    url: vi.fn(() => current),
+    waitForURL: vi.fn(async (predicate: RegExp | ((url: URL) => boolean)) => {
+      while (index < hops.length - 1) {
+        index += 1;
+        current = hops[index];
+        const matches =
+          predicate instanceof RegExp
+            ? predicate.test(current)
+            : predicate(new URL(current));
+        if (matches) return;
+      }
+      throw new Error("Timeout waiting for URL");
+    }),
+    waitForLoadState: vi.fn(async () => {}),
+  };
+}
+
+describe("BrowserAuth.navigateAndLogin", () => {
+  let auth: BrowserAuth;
+  let ssoFlow: { login: ReturnType<typeof vi.fn>; manualLogin: ReturnType<typeof vi.fn>; hasCredentials: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    auth = new BrowserAuth(makeConfig());
+    ssoFlow = {
+      login: vi.fn(async () => true),
+      manualLogin: vi.fn(async () => true),
+      hasCredentials: vi.fn(() => true),
+    };
+    // navigateAndLogin is private; swap the SSO flow so we can assert it stays unused.
+    (auth as any).ssoFlow = ssoFlow;
+  });
+
+  const navigate = (page: unknown): Promise<boolean> =>
+    (auth as any).navigateAndLogin(page);
+
+  it("treats a valid session as authenticated when goto settles on an intermediate SAML hop", async () => {
+    const page = makeRedirectingPage([
+      `${BASE_URL}/d2l/lp/auth/login/samlLogin.d2l`,
+      `${BASE_URL}/d2l/home`,
+    ]);
+
+    await expect(navigate(page)).resolves.toBe(true);
+    expect(ssoFlow.login).not.toHaveBeenCalled();
+    expect(ssoFlow.manualLogin).not.toHaveBeenCalled();
+  });
+
+  it("still performs SSO login when the redirect chain never reaches /d2l/home", async () => {
+    const page = makeRedirectingPage([
+      `${BASE_URL}/d2l/lp/auth/login/login.d2l`,
+      "https://sso.example.edu/idp/profile/SAML2/Redirect/SSO",
+    ]);
+
+    await expect(navigate(page)).resolves.toBe(false);
+    expect(ssoFlow.login).toHaveBeenCalledOnce();
+  });
+
+  it("short-circuits without waiting when goto already lands on /d2l/home", async () => {
+    const page = makeRedirectingPage([`${BASE_URL}/d2l/home`]);
+
+    await expect(navigate(page)).resolves.toBe(true);
+    expect(page.waitForURL).not.toHaveBeenCalled();
+    expect(ssoFlow.login).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #13.

## Problem

`navigateAndLogin()` reads `page.url()` immediately after a `goto()` that settles on `domcontentloaded`:

```js
await page.goto(`${this.config.baseUrl}/d2l/home`, { waitUntil: "domcontentloaded", timeout: 30000 });
const currentUrl = page.url();
const needsLogin = !currentUrl.includes("/d2l/home");
```

At institutions whose SAML flow has an extra redirect hop, that check runs while the URL is still the intermediate hop, so a valid restored session is misread as logged-out. Testing against `brightspace.usc.edu`, the hop is `/d2l/lp/auth/login/samlLogin.d2l`:

```
  - waiting for locator('input#username') to be visible
    - waiting for ".../d2l/lp/auth/login/samlLogin.d2l" navigation to finish...
    - navigated to ".../d2l/home"
  name: 'TimeoutError'   step: 'credentials'
```

The SSO flow then waits 30s for a login form that never renders — the redirect finished to `/d2l/home` moments later. The throw propagates out of `authenticate()`, so `auth-cli.js` never reaches its `session.json` save or the `fs.access` retry block. Result: `~/.d2l-session/` holds only `browser-data/`, every tool call reports "Not authenticated", and re-running auth can never break out of it.

It's a race rather than a hard incompatibility, which is presumably why it doesn't show up at Purdue — that chain settles fast enough to win it.

## Fix

Re-check the URL once the redirect chain settles, capped at 15s, before deciding login is needed. If the page genuinely never reaches `/d2l/home`, the original SSO path runs exactly as before — the only behavioural change is on sessions that were already valid.

## Tests

New `tests/auth/browser-auth-navigate.test.ts` covers three paths:

| Case | Expected |
|---|---|
| `goto` settles on the SAML hop, then reaches `/d2l/home` | authenticated, SSO never invoked |
| Chain never reaches `/d2l/home` | SSO login still runs |
| `goto` lands directly on `/d2l/home` | authenticated, no extra wait |

The first fails on `main` (`expected false to be true`) and passes with the fix; the other two pass either way and guard against over-correcting. Full suite: 58 passed (6 files), `tsc` clean.

## Verification

Against USC with only this change, first-run auth succeeds:

```
[INFO] Already authenticated - skipping SSO login
[INFO] Session cookies active — trying to extract API token
[INFO] Extracted valid Bearer token from localStorage
=== Authentication successful! ===
Session saved to ~/.d2l-session/session.json
```

`get_my_courses` then returns real enrollment data. Issue #13 also notes two smaller things I left out of this PR to keep it focused: the hardcoded `idp.purdue.edu` entityId, and error messages pointing at `.env` when `setup` writes `~/.brightspace-mcp/config.json`. Happy to take either on separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)