### PR TITLE
fix: honour the activeOnly argument in get_my_courses

### DIFF
--- a/src/tools/get-my-courses.ts
+++ b/src/tools/get-my-courses.ts
@@ -56,7 +56,14 @@ export function registerGetMyCourses(
         log("DEBUG", "get_my_courses tool called", { args });
 
         // Parse and validate input
-        const { activeOnly } = GetMyCoursesSchema.parse(args);
+        const { activeOnly: activeOnlyArg } = GetMyCoursesSchema.parse(args);
+
+        // An explicit per-call argument wins; otherwise fall back to the configured
+        // policy. Resolving once here keeps the API query and the post-fetch filter
+        // in agreement — previously the argument shaped the query but the filter
+        // still used config.courseFilter.activeOnly, so activeOnly:false fetched
+        // inactive courses and then discarded them.
+        const activeOnly = activeOnlyArg ?? config.courseFilter.activeOnly;
 
         // Build path - orgUnitTypeId=3 means "Course Offering" type
         const path = apiClient.lp(
@@ -87,7 +94,7 @@ export function registerGetMyCourses(
             isActive: item.Access.IsActive,
             lastAccessed: item.Access.LastAccessed,
           })),
-          config.courseFilter
+          { ...config.courseFilter, activeOnly }
         );
 
         log("INFO", `get_my_courses: Retrieved ${courses.length} courses`);

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -13,7 +13,15 @@ import { z } from "zod";
  */
 
 export const GetMyCoursesSchema = z.object({
-  activeOnly: z.boolean().default(true).describe("Only return currently active courses"),
+  // Intentionally has no default: omitting it falls back to the configured
+  // D2L_ACTIVE_ONLY / config.json policy (true unless the user changed it).
+  // A default here would silently override that configuration on every call.
+  activeOnly: z
+    .boolean()
+    .optional()
+    .describe(
+      "Only return currently active courses. Defaults to the server's configured activeOnly setting (true unless overridden)."
+    ),
 });
 
 export const GetUpcomingDueDatesSchema = z.object({

--- a/tests/tools/get-my-courses.test.ts
+++ b/tests/tools/get-my-courses.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerGetMyCourses } from "../../src/tools/get-my-courses.js";
+import type { AppConfig } from "../../src/types/index.js";
+
+/**
+ * Regression tests for how get_my_courses resolves activeOnly.
+ *
+ * The tool argument shapes the myenrollments query string, but the fetched rows
+ * are then run through applyCourseFilter. If that filter keeps using the global
+ * config value, passing activeOnly:false fetches inactive courses and throws them
+ * away again — the argument silently does nothing.
+ */
+
+const COURSES = [
+  { id: 15853, name: "Sandbox", code: "sandbox", isActive: true },
+  { id: 319544, name: "IDSN-532", code: "20263_34066", isActive: false },
+];
+
+function makeConfig(activeOnly: boolean): AppConfig {
+  return {
+    baseUrl: "https://brightspace.example.edu",
+    sessionDir: "/tmp/nope",
+    tokenTtl: 3600,
+    headless: true,
+    courseFilter: { activeOnly },
+  } as AppConfig;
+}
+
+/** Captures the registered handler and the paths it requests. */
+function setup(config: AppConfig) {
+  const requested: string[] = [];
+  const apiClient = {
+    lp: (p: string) => `/d2l/api/lp/1.0${p}`,
+    get: vi.fn(async (path: string) => {
+      requested.push(path);
+      const activeOnlyQuery = path.includes("isActive=true");
+      const items = COURSES.filter((c) => !activeOnlyQuery || c.isActive);
+      return {
+        Items: items.map((c) => ({
+          OrgUnit: { Id: c.id, Name: c.name, Code: c.code },
+          Access: {
+            ClasslistRoleName: "Instructor",
+            IsActive: c.isActive,
+            LastAccessed: null,
+          },
+        })),
+      };
+    }),
+  };
+
+  let handler: (args: unknown) => Promise<any>;
+  const server = {
+    registerTool: (_name: string, _meta: unknown, fn: (args: unknown) => Promise<any>) => {
+      handler = fn;
+    },
+  };
+
+  registerGetMyCourses(server as any, apiClient as any, config);
+  return { call: (args: unknown) => handler!(args), requested };
+}
+
+const idsOf = (result: any): number[] =>
+  JSON.parse(result.content[0].text).map((c: { id: number }) => c.id);
+
+describe("get_my_courses activeOnly resolution", () => {
+  let config: AppConfig;
+
+  beforeEach(() => {
+    config = makeConfig(true);
+  });
+
+  it("returns inactive courses when the caller passes activeOnly:false", async () => {
+    const { call, requested } = setup(config);
+
+    const result = await call({ activeOnly: false });
+
+    expect(requested[0]).not.toContain("isActive=true");
+    expect(idsOf(result)).toEqual([15853, 319544]);
+  });
+
+  it("filters to active courses when the caller passes activeOnly:true", async () => {
+    const { call, requested } = setup(config);
+
+    const result = await call({ activeOnly: true });
+
+    expect(requested[0]).toContain("isActive=true");
+    expect(idsOf(result)).toEqual([15853]);
+  });
+
+  it("falls back to the configured policy when the argument is omitted", async () => {
+    const { call } = setup(makeConfig(false));
+
+    const result = await call({});
+
+    expect(idsOf(result)).toEqual([15853, 319544]);
+  });
+
+  it("honours a configured activeOnly:true when the argument is omitted", async () => {
+    const { call } = setup(makeConfig(true));
+
+    const result = await call({});
+
+    expect(idsOf(result)).toEqual([15853]);
+  });
+});


### PR DESCRIPTION
## Problem

`get_my_courses`'s `activeOnly` argument can never surface an inactive course, and it fails silently.

The argument shapes the query string (`get-my-courses.ts:63`), but the fetched rows are then filtered using the **global** config value (`get-my-courses.ts:90`):

```js
const { activeOnly } = GetMyCoursesSchema.parse(args);
const path = apiClient.lp(`/enrollments/myenrollments/?orgUnitTypeId=3${activeOnly ? "&isActive=true" : ""}`);
// ...
const courses = applyCourseFilter(response.Items.map(...), config.courseFilter);
```

With the default `config.courseFilter.activeOnly === true`, calling `activeOnly: false` fetches the inactive courses over the wire and then throws every one of them away. The caller sees the identical result either way, with nothing logged to explain it.

Observed against `brightspace.usc.edu`, where the raw endpoint returns four course offerings. `activeOnly: true` and `activeOnly: false` both returned only the single active one; the three inactive courses were fetched and dropped.

There's a second-order effect: because the schema carries `.default(true)`, a user who sets `activeOnly: false` in `~/.brightspace-mcp/config.json` (or `D2L_ACTIVE_ONLY=false`) *still* gets `true` on any call that omits the argument, so the documented config knob doesn't work for default calls either.

## Fix

Resolve `activeOnly` once — explicit argument, else configured policy — and use that single value for both the query string and the filter:

```js
const activeOnly = activeOnlyArg ?? config.courseFilter.activeOnly;
// ...
applyCourseFilter(..., { ...config.courseFilter, activeOnly });
```

The schema's `.default(true)` becomes `.optional()` so an omitted argument defers to configuration rather than overriding it. Effective default is unchanged for anyone who hasn't set the config value: `config.courseFilter.activeOnly` already defaults to `true` in `loadConfig()`.

## Tests

New `tests/tools/get-my-courses.test.ts`, driving the registered handler against a stubbed API client that mirrors the real `isActive=true` query behaviour:

| Case | Expected |
|---|---|
| `activeOnly: false` | active + inactive returned; query omits `isActive=true` |
| `activeOnly: true` | active only; query includes `isActive=true` |
| omitted, config `activeOnly: false` | active + inactive returned |
| omitted, config `activeOnly: true` | active only |

Rows 1 and 3 fail on `main` (`expected [ 15853 ] to deeply equal [ 15853, 319544 ]`) and pass with the fix. Rows 2 and 4 pass either way, guarding the active-only path. Full suite: 59 passed (6 files), `tsc` clean.

Independent of #14 — different files, either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)