### PR TITLE
fix: submit the account name before the password on Microsoft Entra

### DIFF
--- a/src/auth/purdue-sso.ts
+++ b/src/auth/purdue-sso.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT — see LICENSE file for details.
  */
 
-import type { Page } from "playwright";
+import type { ElementHandle, Page } from "playwright";
 import { BrowserAuthError } from "../utils/errors.js";
 import { log } from "../utils/logger.js";
 
@@ -13,7 +13,23 @@ const SELECTORS = {
   passwordInput: "input#password",
   submitButton: 'button[name="_eventId_proceed"]',
   staySignedInYes: "input[type=submit][value='Yes']",
+  // Purdue's proceed button, D2L's own, and the generic submit used by Entra
+  // (input#idSIButton9) and most other identity providers.
+  formSubmit: 'button[name="_eventId_proceed"], button.d2l-button, input[type="submit"]',
 } as const;
+
+// Entra labels the account-name button "Next" and only shows "Sign in" on the
+// view that follows. Both are input#idSIButton9, so the label tells them apart.
+const ACCOUNT_NAME_BUTTON = /^next$/i;
+
+/** Visible text of a button, or the value of a submit input. */
+async function controlLabel(
+  handle: ElementHandle<SVGElement | HTMLElement>
+): Promise<string> {
+  return handle.evaluate((el) =>
+    ((el as HTMLInputElement).value || el.textContent || "").trim()
+  );
+}
 
 interface PurdueSSOConfig {
   username?: string;
@@ -131,33 +147,79 @@ export class PurdueSSOFlow {
       }
 
       log("INFO", "Entering credentials");
-      // Try to figure out which input actually exists
-      const usernameField = await page.$(usernameSelector);
+      const usernameField = await this.findVisible(page, usernameSelector);
       if (usernameField) {
         await usernameField.fill(this.config.username);
       }
 
+      // Microsoft Entra puts a password box on its account-name page as well,
+      // but the button there only advances to the next view. Submit the account
+      // name first so the password lands on the page that actually signs in.
+      await this.submitAccountName(page);
+
       const passwordSelector = 'input#password, input[type="password"]';
-      const passwordField = await page.$(passwordSelector);
+      const passwordField = await this.findVisible(page, passwordSelector);
       if (passwordField) {
         await passwordField.fill(this.config.password);
       }
 
-      // Try to click the submit button. Could be Purdue's proceed, or Albany's Log In, or a generic button
-      const submitSelector = 'button[name="_eventId_proceed"], button.d2l-button, input[type="submit"]';
-      const submitButton = await page.$(submitSelector);
+      const submitButton = await this.findVisible(page, SELECTORS.formSubmit);
       if (submitButton) {
         await submitButton.click();
       } else {
         // Fallback: just hit Enter on the password field
         await passwordField?.press('Enter');
       }
-      
+
       await page.waitForLoadState("networkidle");
     } catch (error) {
       log("WARN", "Automated credentials entry failed, will fallback to manual login.", error);
       throw error;
     }
+  }
+
+  /**
+   * Resolve a control only when it is actually on screen.
+   *
+   * Entra is a single-page app: the account-name view stays in the DOM once
+   * the password view replaces it, so a plain page.$() returns the hidden
+   * first-page input or button that precedes the live one in document order.
+   * Filling or clicking those stalls on Playwright's actionability wait.
+   */
+  private async findVisible(
+    page: Page,
+    selector: string
+  ): Promise<ElementHandle<SVGElement | HTMLElement> | null> {
+    for (const handle of await page.$$(selector)) {
+      if (await handle.isVisible()) return handle;
+    }
+    return null;
+  }
+
+  /**
+   * Advance Microsoft Entra's account-name page.
+   *
+   * That page carries a password box of its own, and Playwright reports it as
+   * visible, so presence cannot tell it apart from a single-page form. The
+   * button label can: it reads "Next" there and "Sign in" on the view that
+   * follows. Filling the password against the account-name page leaves the
+   * browser parked with both fields populated and nothing submitted.
+   */
+  private async submitAccountName(page: Page): Promise<void> {
+    const submit = await this.findVisible(page, SELECTORS.formSubmit);
+    if (!submit) return;
+    if (!ACCOUNT_NAME_BUTTON.test(await controlLabel(submit))) return;
+
+    log("INFO", "Account-name page detected — submitting account name");
+    await submit.click();
+
+    // The sign-in view has arrived once the button stops saying "Next".
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      await page.waitForTimeout(500);
+      const current = await this.findVisible(page, SELECTORS.formSubmit);
+      if (current && !ACCOUNT_NAME_BUTTON.test(await controlLabel(current))) return;
+    }
+    log("WARN", "Sign-in page did not appear after submitting the account name");
   }
 
   private async handleMFA(page: Page): Promise<void> {

--- a/tests/auth/purdue-sso-credentials.test.ts
+++ b/tests/auth/purdue-sso-credentials.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { PurdueSSOFlow } from "../../src/auth/purdue-sso.js";
+
+/**
+ * Regression tests for enterCredentials() against Microsoft Entra ID.
+ *
+ * Shibboleth and CAS render the username and password boxes together and one
+ * fill-fill-submit pass completes them. Entra looks the same to a selector but
+ * is not: its account-name page carries a password box that Playwright reports
+ * as visible, while the button only advances to the next view. Filling the
+ * password there and pressing that button leaves the browser parked on the
+ * sign-in page with both fields populated and nothing submitted, while the
+ * flow moves on to wait for an MFA prompt that can never arrive.
+ *
+ * The button label is what separates the two: "Next" on the account-name page,
+ * "Sign in" on the page that follows.
+ */
+
+const USERNAME = "student@example.edu";
+const PASSWORD = "hunter2";
+
+function makeField(visible: boolean, label = "") {
+  return {
+    fill: vi.fn(async () => {}),
+    isVisible: vi.fn(async () => visible),
+    click: vi.fn(async () => {}),
+    press: vi.fn(async () => {}),
+    evaluate: vi.fn(async (fn: (el: unknown) => unknown) =>
+      fn({ value: label, textContent: label }),
+    ),
+  };
+}
+
+/**
+ * Fake Page. With `entra`, it behaves like Microsoft's two-view form: a
+ * password box and a "Next" button up front, replaced by a second password box
+ * and a "Sign in" button once the account name is submitted.
+ */
+function makePage(opts: { entra?: boolean; submitLabel?: string } = {}) {
+  const username = makeField(true);
+  const accountPassword = makeField(true);
+  const signInPassword = makeField(true);
+  const nextButton = makeField(true, "Next");
+  const signInButton = makeField(true, opts.submitLabel ?? "Sign in");
+  let advanced = false;
+
+  nextButton.click = vi.fn(async () => {
+    advanced = true;
+  });
+
+  const matches = (selector: string) => {
+    if (selector.includes("input#username")) return [username];
+    if (selector.includes("input#password")) {
+      if (!opts.entra) return [signInPassword];
+      return advanced ? [signInPassword] : [accountPassword];
+    }
+    if (selector.includes("_eventId_proceed")) {
+      if (!opts.entra) return [signInButton];
+      return [advanced ? signInButton : nextButton];
+    }
+    return [];
+  };
+
+  return {
+    fields: { username, accountPassword, signInPassword, nextButton, signInButton },
+    $: vi.fn(async (selector: string) => matches(selector)[0] ?? null),
+    $$: vi.fn(async (selector: string) => matches(selector)),
+    waitForSelector: vi.fn(async () => null),
+    waitForTimeout: vi.fn(async () => {}),
+    waitForLoadState: vi.fn(async () => {}),
+  };
+}
+
+const enterCredentials = (flow: PurdueSSOFlow, page: unknown): Promise<void> =>
+  (flow as any).enterCredentials(page);
+
+describe("PurdueSSOFlow.enterCredentials", () => {
+  it("submits the account name before entering the password on Entra", async () => {
+    const page = makePage({ entra: true });
+    const flow = new PurdueSSOFlow({ username: USERNAME, password: PASSWORD });
+
+    await enterCredentials(flow, page);
+
+    expect(page.fields.username.fill).toHaveBeenCalledWith(USERNAME);
+    expect(page.fields.nextButton.click).toHaveBeenCalledOnce();
+    // The password belongs to the sign-in view, not the account-name page.
+    expect(page.fields.accountPassword.fill).not.toHaveBeenCalled();
+    expect(page.fields.signInPassword.fill).toHaveBeenCalledWith(PASSWORD);
+    expect(page.fields.signInButton.click).toHaveBeenCalledOnce();
+  });
+
+  it("leaves single-page forms on their existing one-pass path", async () => {
+    const page = makePage({ submitLabel: "Log In" });
+    const flow = new PurdueSSOFlow({ username: USERNAME, password: PASSWORD });
+
+    await enterCredentials(flow, page);
+
+    expect(page.fields.username.fill).toHaveBeenCalledWith(USERNAME);
+    expect(page.fields.signInPassword.fill).toHaveBeenCalledWith(PASSWORD);
+    expect(page.fields.signInButton.click).toHaveBeenCalledOnce();
+    // No account-name hop: the button never said "Next".
+    expect(page.fields.nextButton.click).not.toHaveBeenCalled();
+  });
+
+  it("treats a button labelled Next as an account-name page whatever the case", async () => {
+    const page = makePage({ entra: true });
+    page.fields.nextButton.evaluate = vi.fn(async (fn: (el: unknown) => unknown) =>
+      fn({ value: "NEXT", textContent: "NEXT" }),
+    );
+    const flow = new PurdueSSOFlow({ username: USERNAME, password: PASSWORD });
+
+    await enterCredentials(flow, page);
+
+    expect(page.fields.nextButton.click).toHaveBeenCalledOnce();
+    expect(page.fields.signInButton.click).toHaveBeenCalledOnce();
+  });
+
+  it("still rejects when no password is configured", async () => {
+    const page = makePage();
+    const flow = new PurdueSSOFlow({ username: USERNAME });
+
+    await expect(enterCredentials(flow, page)).rejects.toThrow(/Password is required/);
+  });
+});


### PR DESCRIPTION
Fixes #17.

## Problem

`enterCredentials` assumes a sign-in form carries its username and password boxes together, fills both, and presses submit once. Microsoft Entra ID looks like that to a selector but does not behave like it.

Entra's account-name page carries a password box of its own, and Playwright reports it as visible:

```
username  input#i0116       visible=true
password  input#i0118       visible=true     <- on the account-name page
submit    input#idSIButton9 visible=true  value="Next"
```

So nothing about the controls distinguishes that page from a single-page Shibboleth form. `enterCredentials` fills the password there and clicks the only submit on the page — which is labelled **Next** and merely advances to the sign-in view.

The result is a sign-in that stalls with both fields visibly populated and the Sign in button never pressed, while `handleMFA` moves on to wait for an approval that cannot arrive, because the form was never submitted. After 120s the run dies at `token_interception`.

`purdue-sso.ts:141` is where the wrong password box is taken:

```js
const passwordSelector = 'input#password, input[type="password"]';
const passwordField = await page.$(passwordSelector);
```

Since #16 widened the username selector to include `input[type="email"]`, the account name does get filled, so the symptom on current `main` differs from the `input#username` timeout reported against 1.2.6. The outcome is the same: automated sign-in cannot finish at an Entra-fronted institution.

## Fix

The button label is what separates the two pages — **Next** on the account-name page, **Sign in** on the one that follows. Both are `input#idSIButton9`, so the label is the only reliable signal:

```js
await this.submitAccountName(page);          // no-op unless the button says "Next"

const passwordField = await this.findVisible(page, passwordSelector);
if (passwordField) await passwordField.fill(this.config.password);

const submitButton = await this.findVisible(page, SELECTORS.formSubmit);
```

`submitAccountName` clicks Next, waits for the label to stop saying Next, and returns. Forms whose button never says Next — Shibboleth, CAS — take exactly the path they take today.

Controls are also resolved through `findVisible`, which scans for the first visible match, so a stale hidden input left behind by a view swap cannot shadow the live one.

## Tests

New `tests/auth/purdue-sso-credentials.test.ts`:

| Case | Expected |
|---|---|
| Entra's two views | account name submitted first; password fills the sign-in view, not the account page; Sign in clicked |
| Single-page form | one fill-fill-submit pass; no account-name hop |
| Button labelled `NEXT` | matched case-insensitively |
| No password configured | still rejects |

Rows 1 and 3 fail on `main`; all four pass with the fix. Full suite: 82 passed (9 files), `tsc` clean.

## Verification

I don't have a Purdue account, so I can't reproduce #17's chain directly. Two things I could do:

**An offline replica of Entra's two views**, built to match the DOM above — visible password box and a "Next" button on page one — driven with real Playwright. It reproduces the stall exactly, and passes with the fix. Reverting only this commit puts it back.

**A live sign-in at SUNY Poly**, whose Brightspace federates to Entra through `login.microsoftonline.com`. On `main` it stalled with both fields populated; with this commit:

```
[INFO] Entering credentials
[INFO] Account-name page detected — submitting account name
[INFO] MFA completed — redirected to: ...
[INFO] Login successful - reached Brightspace home
```

Microsoft serves that form for every tenant, so the selectors should be the ones Purdue lands on — but confirmation from a Purdue account would settle it.

## Could someone at Purdue try this out?

@ElliotDrel or @RohanMuppa — whenever either of you has a spare few minutes, could one of you sign in with this branch on your Purdue account? That's the one thing I can't check myself, and it's the whole question this PR turns on.

Three commands, from a clone of the repo:

```bash
gh pr checkout 19            # this PR
npm install && npm run build
node build/index.js auth
```

A Chrome window opens. **Please don't click anything in it** — just wait, and approve the Duo push when it reaches your phone. Clicking is exactly what hides the bug, since a person is faster than the automation and fills the form before it gets there.

**If the fix works**, the terminal prints a line that does not exist on `main`:

```
[INFO] Account-name page detected — submitting account name
```

and sign-in carries on to `Login successful - reached Brightspace home`.

**If it doesn't**, the browser stops on Microsoft's page with your email and password both filled in and the Sign in button never pressed — that's the bug in #17, and it means Purdue's form differs from the one I tested against. Either result is useful to me; pasting the terminal output is plenty, and no rush at all.

## Notes

- **No version bump.** `main` is at 1.2.8 while npm shows 1.2.6, so there are unpublished bumps already; I didn't want to collide with your release commits. Happy to add one.
- `docs/how-it-works.svg` unchanged — this doesn't alter the architecture, only which form the login step can drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
