### PR TITLE
feat: add --suny preset for the shared SUNY Brightspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,4 +27,4 @@ No Co-Authored-By lines. No phase/plan numbers.
 - Auth: Playwright-based browser login with Duo MFA support
 - Auto-reauth on token expiry via `AuthRunner`
 - CLI subcommands: `setup`, `auth`, default (MCP server)
-- School presets: `--purdue` flag (extensible via `SCHOOL_PRESETS` in `src/setup.ts`)
+- School presets: `--purdue` and `--suny` flags (extensible via `SCHOOL_PRESETS` in `src/setup.ts`; per-school login handlers are registered in `src/auth/sso-flow.ts`)

--- a/LLMs.md
+++ b/LLMs.md
@@ -36,8 +36,15 @@ If the user is at Purdue, use the preset:
 npx brightspace-mcp-server setup --purdue
 ```
 
+If the user is at a SUNY campus, use the SUNY preset. It also asks which campus
+they attend, which lets sign-in skip SUNY's shared campus picker:
+
+```bash
+npx brightspace-mcp-server setup --suny
+```
+
 The wizard:
-- prompts for the school's Brightspace URL (skipped with `--purdue`)
+- prompts for the school's Brightspace URL (skipped with `--purdue` or `--suny`)
 - launches a Playwright Chromium browser for login and MFA (Duo push, etc.)
 - saves credentials to `~/.brightspace-mcp/config.json` (0600)
 - writes the encrypted session to `~/.d2l-session/session.json` (AES-256-GCM)
@@ -111,7 +118,9 @@ src/
   auth/
     auth-runner.ts          Orchestrates reauth on 401/expiry
     browser-auth.ts         Playwright-driven login flow
-    purdue-sso.ts           Purdue-specific SSO handler
+    sso-flow.ts             Picks the login flow for the configured host
+    purdue-sso.ts           Default SSO handler (Shibboleth, CAS, Entra forms)
+    suny-sso.ts             SUNY campus selection
     session-store.ts        AES-256-GCM session persistence
     token-manager.ts        Token refresh and validation
   utils/
@@ -134,6 +143,7 @@ src/
 |---------|--------------|
 | `npx brightspace-mcp-server setup` | Interactive setup wizard |
 | `npx brightspace-mcp-server setup --purdue` | Setup with Purdue preset |
+| `npx brightspace-mcp-server setup --suny` | Setup with SUNY preset (also asks for campus) |
 | `npx brightspace-mcp-server auth` | Manual reauth |
 | `npx -y brightspace-mcp-server@latest` | Run the MCP server (registered in AI client config) |
 | `npm run build` | Compile TypeScript to `build/` |
@@ -152,7 +162,7 @@ src/
 
 ## Adding a school
 
-Add a preset to `SCHOOL_PRESETS` in `src/setup.ts`. If the school uses a non-standard login flow (SAML, Shibboleth, custom SSO), add a handler in `src/auth/` alongside `purdue-sso.ts`.
+Add a preset to `SCHOOL_PRESETS` in `src/setup.ts`. If the school uses a non-standard login flow (SAML, Shibboleth, custom SSO), add a handler in `src/auth/` alongside `purdue-sso.ts` and register it in `createSSOFlow()` in `src/auth/sso-flow.ts`.
 
 ## Adding a tool
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Talk to your Brightspace courses with AI. Ask about grades, due dates, announcem
 
 This is an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that connects your AI to D2L Brightspace so it can pull your grades, assignments, syllabus, and course content on demand.
 
-Works with any school that uses D2L Brightspace, including Purdue, USC, and hundreds more.
+Works with any school that uses D2L Brightspace, including Purdue, SUNY, USC, and hundreds more.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/RohanMuppa/brightspace-mcp-server/main/docs/how-it-works.svg" alt="Architecture diagram" width="100%">
@@ -28,7 +28,7 @@ Paste this into Claude Code, Cursor, Windsurf, Copilot, Codex, or any AI coding 
 ```
 Install brightspace-mcp-server for me by following
 https://github.com/RohanMuppa/brightspace-mcp-server/blob/main/LLMs.md
-(use --purdue if I'm at Purdue).
+(use --purdue if I'm at Purdue, or --suny if I'm at a SUNY campus).
 ```
 
 **Option 2: Run it yourself**
@@ -41,6 +41,13 @@ Purdue students can add `--purdue` to skip entering the school URL:
 
 ```bash
 npx brightspace-mcp-server setup --purdue
+```
+
+SUNY campuses share one Brightspace site, so `--suny` also asks which campus
+you're at and skips SUNY's campus picker when you sign in:
+
+```bash
+npx brightspace-mcp-server setup --suny
 ```
 
 The wizard walks you through login, MFA, and auto configures Claude Desktop and Cursor. Restart your AI client when it finishes.

--- a/src/auth-cli.ts
+++ b/src/auth-cli.ts
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
     // Check for credentials and provide status
     if (config.username && config.password) {
       console.log(`Authenticating as: ${config.username}`);
-      console.log("Approve the Duo MFA request on your phone when prompted.");
+      console.log("Approve the sign-in request on your phone when prompted.");
     } else {
       console.log("No credentials. Opening browser for manual login.");
     }
@@ -94,7 +94,7 @@ async function main(): Promise<void> {
     console.error("\nError:", error instanceof Error ? error.message : String(error));
     console.error("\nTroubleshooting tips:");
     console.error("1. Ensure D2L_USERNAME and D2L_PASSWORD are set correctly in .env");
-    console.error("2. If MFA approval failed, make sure you approved the Duo push on your phone");
+    console.error("2. If MFA approval failed, make sure you approved the sign-in request on your phone");
     console.error("3. Check that you have a stable internet connection");
     console.error("4. Try running with D2L_HEADLESS=false to see the browser");
     console.error("\nFor more details, check the error message above.\n");

--- a/src/auth/browser-auth.ts
+++ b/src/auth/browser-auth.ts
@@ -12,18 +12,16 @@ import * as os from "node:os";
 import type { AppConfig, TokenData } from "../types/index.js";
 import { BrowserAuthError } from "../utils/errors.js";
 import { log } from "../utils/logger.js";
-import { PurdueSSOFlow } from "./purdue-sso.js";
+import { createSSOFlow } from "./sso-flow.js";
+import type { SSOFlow } from "./sso-flow.js";
 
 export class BrowserAuth {
   private config: AppConfig;
-  private ssoFlow: PurdueSSOFlow;
+  private ssoFlow: SSOFlow;
 
   constructor(config: AppConfig) {
     this.config = config;
-    this.ssoFlow = new PurdueSSOFlow({
-      username: config.username,
-      password: config.password,
-    });
+    this.ssoFlow = createSSOFlow(config);
   }
 
   /**

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -6,6 +6,9 @@
 
 export { BrowserAuth } from "./browser-auth.js";
 export { PurdueSSOFlow } from "./purdue-sso.js";
+export { SunySSOFlow, isSunyBrightspace } from "./suny-sso.js";
+export { createSSOFlow } from "./sso-flow.js";
+export type { SSOFlow } from "./sso-flow.js";
 export { TokenManager } from "./token-manager.js";
 export { SessionStore } from "./session-store.js";
 export { AuthRunner } from "./auth-runner.js";

--- a/src/auth/purdue-sso.ts
+++ b/src/auth/purdue-sso.ts
@@ -59,7 +59,7 @@ export class PurdueSSOFlow {
    */
   async login(page: Page): Promise<boolean> {
     try {
-      log("INFO", "Starting Purdue SSO login flow");
+      log("INFO", "Starting SSO login flow");
 
       // Step 1: Handle campus selector on purdue.brightspace.com/d2l/login
       await this.handleCampusSelector(page);

--- a/src/auth/purdue-sso.ts
+++ b/src/auth/purdue-sso.ts
@@ -4,7 +4,7 @@
  * Licensed under MIT — see LICENSE file for details.
  */
 
-import type { Page } from "playwright";
+import type { ElementHandle, Page } from "playwright";
 import { BrowserAuthError } from "../utils/errors.js";
 import { log } from "../utils/logger.js";
 
@@ -13,7 +13,23 @@ const SELECTORS = {
   passwordInput: "input#password",
   submitButton: 'button[name="_eventId_proceed"]',
   staySignedInYes: "input[type=submit][value='Yes']",
+  // Purdue's proceed button, D2L's own, and the generic submit used by Entra
+  // (input#idSIButton9) and most other identity providers.
+  formSubmit: 'button[name="_eventId_proceed"], button.d2l-button, input[type="submit"]',
 } as const;
+
+// Entra labels the account-name button "Next" and only shows "Sign in" on the
+// view that follows. Both are input#idSIButton9, so the label tells them apart.
+const ACCOUNT_NAME_BUTTON = /^next$/i;
+
+/** Visible text of a button, or the value of a submit input. */
+async function controlLabel(
+  handle: ElementHandle<SVGElement | HTMLElement>
+): Promise<string> {
+  return handle.evaluate((el) =>
+    ((el as HTMLInputElement).value || el.textContent || "").trim()
+  );
+}
 
 interface PurdueSSOConfig {
   username?: string;
@@ -131,33 +147,79 @@ export class PurdueSSOFlow {
       }
 
       log("INFO", "Entering credentials");
-      // Try to figure out which input actually exists
-      const usernameField = await page.$(usernameSelector);
+      const usernameField = await this.findVisible(page, usernameSelector);
       if (usernameField) {
         await usernameField.fill(this.config.username);
       }
 
+      // Microsoft Entra puts a password box on its account-name page as well,
+      // but the button there only advances to the next view. Submit the account
+      // name first so the password lands on the page that actually signs in.
+      await this.submitAccountName(page);
+
       const passwordSelector = 'input#password, input[type="password"]';
-      const passwordField = await page.$(passwordSelector);
+      const passwordField = await this.findVisible(page, passwordSelector);
       if (passwordField) {
         await passwordField.fill(this.config.password);
       }
 
-      // Try to click the submit button. Could be Purdue's proceed, or Albany's Log In, or a generic button
-      const submitSelector = 'button[name="_eventId_proceed"], button.d2l-button, input[type="submit"]';
-      const submitButton = await page.$(submitSelector);
+      const submitButton = await this.findVisible(page, SELECTORS.formSubmit);
       if (submitButton) {
         await submitButton.click();
       } else {
         // Fallback: just hit Enter on the password field
         await passwordField?.press('Enter');
       }
-      
+
       await page.waitForLoadState("networkidle");
     } catch (error) {
       log("WARN", "Automated credentials entry failed, will fallback to manual login.", error);
       throw error;
     }
+  }
+
+  /**
+   * Resolve a control only when it is actually on screen.
+   *
+   * Entra is a single-page app: the account-name view stays in the DOM once
+   * the password view replaces it, so a plain page.$() returns the hidden
+   * first-page input or button that precedes the live one in document order.
+   * Filling or clicking those stalls on Playwright's actionability wait.
+   */
+  private async findVisible(
+    page: Page,
+    selector: string
+  ): Promise<ElementHandle<SVGElement | HTMLElement> | null> {
+    for (const handle of await page.$$(selector)) {
+      if (await handle.isVisible()) return handle;
+    }
+    return null;
+  }
+
+  /**
+   * Advance Microsoft Entra's account-name page.
+   *
+   * That page carries a password box of its own, and Playwright reports it as
+   * visible, so presence cannot tell it apart from a single-page form. The
+   * button label can: it reads "Next" there and "Sign in" on the view that
+   * follows. Filling the password against the account-name page leaves the
+   * browser parked with both fields populated and nothing submitted.
+   */
+  private async submitAccountName(page: Page): Promise<void> {
+    const submit = await this.findVisible(page, SELECTORS.formSubmit);
+    if (!submit) return;
+    if (!ACCOUNT_NAME_BUTTON.test(await controlLabel(submit))) return;
+
+    log("INFO", "Account-name page detected — submitting account name");
+    await submit.click();
+
+    // The sign-in view has arrived once the button stops saying "Next".
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      await page.waitForTimeout(500);
+      const current = await this.findVisible(page, SELECTORS.formSubmit);
+      if (current && !ACCOUNT_NAME_BUTTON.test(await controlLabel(current))) return;
+    }
+    log("WARN", "Sign-in page did not appear after submitting the account name");
   }
 
   private async handleMFA(page: Page): Promise<void> {

--- a/src/auth/sso-flow.ts
+++ b/src/auth/sso-flow.ts
@@ -1,0 +1,36 @@
+/**
+ * Brightspace MCP Server
+ * Copyright (c) 2026 Rohan Muppa. All rights reserved.
+ * Licensed under MIT — see LICENSE file for details.
+ */
+
+import type { Page } from "playwright";
+import type { AppConfig } from "../types/index.js";
+import { PurdueSSOFlow } from "./purdue-sso.js";
+import { SunySSOFlow, isSunyBrightspace } from "./suny-sso.js";
+
+/** The browser login sequence for one institution's identity provider. */
+export interface SSOFlow {
+  /** True when saved credentials allow an automated sign-in attempt. */
+  hasCredentials(): boolean;
+  /** Drive the sign-in form. Resolves false on timeout so the caller can fall back. */
+  login(page: Page): Promise<boolean>;
+  /** Wait for the user to sign in themselves in a visible browser. */
+  manualLogin(page: Page): Promise<boolean>;
+}
+
+/**
+ * Pick the login sequence for the configured Brightspace host. Schools whose
+ * identity provider needs extra steps get their own handler here; everything
+ * else uses the default flow, which already covers the common Shibboleth,
+ * CAS, and Microsoft Entra forms.
+ */
+export function createSSOFlow(config: AppConfig): SSOFlow {
+  const credentials = { username: config.username, password: config.password };
+
+  if (isSunyBrightspace(config.baseUrl)) {
+    return new SunySSOFlow({ ...credentials, campus: config.campus });
+  }
+
+  return new PurdueSSOFlow(credentials);
+}

--- a/src/auth/suny-sso.ts
+++ b/src/auth/suny-sso.ts
@@ -1,0 +1,177 @@
+/**
+ * Brightspace MCP Server
+ * Copyright (c) 2026 Rohan Muppa. All rights reserved.
+ * Licensed under MIT — see LICENSE file for details.
+ */
+
+import type { Page } from "playwright";
+import { PurdueSSOFlow } from "./purdue-sso.js";
+import { log } from "../utils/logger.js";
+
+/** SUNY campuses share one Brightspace tenant behind one Shibboleth IdP. */
+const SUNY_BRIGHTSPACE_HOST = "mylearning.suny.edu";
+const SUNY_IDP_ENTITY_ID = "https://idm.suny.edu/shibboleth/idp/";
+const SUNY_IDM_HOST = "idm.suny.edu";
+
+const SELECTORS = {
+  campusSelect: "select#campus",
+  campusSubmit: '#selectionForm button[type="submit"]',
+} as const;
+
+interface SunySSOConfig {
+  username?: string;
+  password?: string;
+  /** Campus name or numeric code, matched against SUNY's own dropdown. */
+  campus?: string;
+}
+
+interface CampusOption {
+  value: string;
+  label: string;
+}
+
+/** True for the shared SUNY Brightspace instance. */
+export function isSunyBrightspace(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === SUNY_BRIGHTSPACE_HOST;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * SUNY carries its own hostname inside the redirect parameters it round-trips,
+ * so compare the host rather than searching the whole URL.
+ */
+function isSunyIdp(url: string): boolean {
+  try {
+    return new URL(url).hostname.toLowerCase() === SUNY_IDM_HOST;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Login flow for the shared SUNY Brightspace instance.
+ *
+ * SUNY puts two extra pages in front of the campus identity provider: the
+ * Brightspace campus selector, whose buttons sit in a shadow DOM, and SUNY's
+ * own campus dropdown at idm.suny.edu. This handler clears both, then hands
+ * off to the default flow, which already knows the Shibboleth, CAS, and
+ * Microsoft Entra sign-in forms the individual campuses use.
+ */
+export class SunySSOFlow {
+  private config: SunySSOConfig;
+  private defaultFlow: PurdueSSOFlow;
+
+  constructor(config: SunySSOConfig) {
+    this.config = config;
+    this.defaultFlow = new PurdueSSOFlow({
+      username: config.username,
+      password: config.password,
+    });
+  }
+
+  hasCredentials(): boolean {
+    return this.defaultFlow.hasCredentials();
+  }
+
+  async login(page: Page): Promise<boolean> {
+    try {
+      await this.startSamlLogin(page);
+      await this.selectCampus(page);
+    } catch (error) {
+      log("ERROR", "SUNY campus selection failed", error);
+      return false;
+    }
+    return this.defaultFlow.login(page);
+  }
+
+  async manualLogin(page: Page): Promise<boolean> {
+    try {
+      // Clear the shadow-DOM selector and, when configured, the campus
+      // dropdown, so the user lands directly on their campus sign-in page.
+      await this.startSamlLogin(page);
+      await this.selectCampus(page);
+    } catch (error) {
+      log("DEBUG", "Could not pre-fill SUNY campus selection", error);
+    }
+    return this.defaultFlow.manualLogin(page);
+  }
+
+  /**
+   * Brightspace's own campus selector renders its buttons in a shadow DOM, so
+   * go straight to the SAML endpoint that selector would have reached.
+   */
+  private async startSamlLogin(page: Page): Promise<void> {
+    const currentUrl = page.url();
+    if (!currentUrl.includes("/d2l/login")) return;
+
+    const origin = new URL(currentUrl).origin;
+    log("INFO", "Campus selector detected — navigating directly to SUNY's SAML endpoint");
+    await page.goto(
+      `${origin}/d2l/lp/auth/saml/initiate-login?entityId=${SUNY_IDP_ENTITY_ID}`,
+      { waitUntil: "domcontentloaded", timeout: 30000 }
+    );
+  }
+
+  /**
+   * Answer SUNY's "Select Campus" dropdown. Without a configured campus the
+   * page is left for the user, who is already at the browser for MFA.
+   */
+  private async selectCampus(page: Page): Promise<void> {
+    if (!isSunyIdp(page.url())) return;
+
+    try {
+      // idm.suny.edu sits behind a bot check, so the form can take a few
+      // seconds to appear even on a fast connection.
+      await page.waitForSelector(SELECTORS.campusSelect, { timeout: 45000 });
+    } catch {
+      log("DEBUG", "No SUNY campus dropdown found — continuing to the sign-in form");
+      return;
+    }
+
+    const options = await page.$$eval(`${SELECTORS.campusSelect} option`, (nodes) =>
+      nodes
+        .map((node) => ({
+          value: (node as HTMLOptionElement).value,
+          label: (node.textContent ?? "").trim(),
+        }))
+        .filter((option) => option.value !== "")
+    );
+
+    if (!this.config.campus) {
+      log("WARN", "No campus configured — choose your campus in the browser window.");
+      log("INFO", "Set one with: brightspace-mcp-server setup --suny");
+      return;
+    }
+
+    const match = this.findCampus(options);
+    if (!match) {
+      log("WARN", `Campus "${this.config.campus}" did not match any SUNY campus.`);
+      log("INFO", `Available: ${options.map((o) => o.label).join(", ")}`);
+      log("WARN", "Choose your campus in the browser window to continue.");
+      return;
+    }
+
+    log("INFO", `Selecting campus ${match.label} (${match.value})`);
+    await page.selectOption(SELECTORS.campusSelect, match.value);
+    await page.click(SELECTORS.campusSubmit);
+  }
+
+  /**
+   * Resolve the configured campus against SUNY's live option list, so no copy
+   * of the campus table has to be kept in this repo. Matches a numeric code or
+   * a campus name, exactly first and then as a prefix.
+   */
+  private findCampus(options: CampusOption[]): CampusOption | undefined {
+    const wanted = this.config.campus?.trim().toLowerCase();
+    if (!wanted) return undefined;
+
+    return (
+      options.find((option) => option.value.toLowerCase() === wanted) ??
+      options.find((option) => option.label.toLowerCase() === wanted) ??
+      options.find((option) => option.label.toLowerCase().startsWith(wanted))
+    );
+  }
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -31,6 +31,10 @@ interface SchoolPreset {
   baseUrl: string;
   usernameLabel: string;
   mfaNote: string;
+  /** Asked only by shared instances that host several campuses. */
+  campusPrompt?: string;
+  /** Shown above the username prompt when the expected format is not obvious. */
+  usernameHint?: string;
 }
 
 const SCHOOL_PRESETS: Record<string, SchoolPreset> = {
@@ -39,6 +43,14 @@ const SCHOOL_PRESETS: Record<string, SchoolPreset> = {
     baseUrl: "https://purdue.brightspace.com",
     usernameLabel: "Purdue career account username",
     mfaNote: "Approve the Duo push on your phone.",
+  },
+  suny: {
+    name: "SUNY",
+    baseUrl: "https://mylearning.suny.edu",
+    usernameLabel: "SUNY campus username",
+    mfaNote: "Approve the sign-in request from your campus MFA app.",
+    campusPrompt: "Which SUNY campus are you at? (e.g. SUNY Poly)",
+    usernameHint: "Most campuses want the full sign-in address, e.g. abc123@sunypoly.edu",
   },
 };
 
@@ -317,10 +329,26 @@ async function main(): Promise<void> {
     console.log("");
   }
 
+  // ── Campus (shared multi-campus instances only) ──────────────────
+  let campus = "";
+  if (preset?.campusPrompt) {
+    console.log(dim("  Several campuses share this Brightspace site."));
+    campus = await ask(rl, `${preset.campusPrompt} `);
+    console.log(
+      campus
+        ? dim(`  → ${campus}`)
+        : dim("  No campus set — you'll pick it in the browser at sign-in."),
+    );
+    console.log("");
+  }
+
   // ── Step 2: Username ─────────────────────────────────────────────
   const usernamePrompt = preset
     ? `What is your ${preset.usernameLabel}? `
     : "What is your Brightspace username? ";
+  if (preset?.usernameHint) {
+    console.log(dim(`  ${preset.usernameHint}`));
+  }
   let username = "";
   while (!username) {
     username = await ask(rl, usernamePrompt);
@@ -356,7 +384,7 @@ async function main(): Promise<void> {
   if (preset) {
     console.log(dim(`  MFA: ${preset.mfaNote}`));
   } else {
-    console.log(dim("  MFA: You will be prompted to approve via Duo on your phone during auth."));
+    console.log(dim("  MFA: You will be prompted to approve the sign-in on your phone during auth."));
   }
   console.log("");
 
@@ -366,6 +394,9 @@ async function main(): Promise<void> {
     username,
     password,
   };
+  if (campus) {
+    config.campus = campus;
+  }
 
   saveConfigStore(config);
   console.log(green("  Config saved to: " + getConfigStorePath()));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,8 @@ export interface AppConfig {
   headless: boolean;
   username?: string;
   password?: string;
+  /** Campus within a shared multi-campus Brightspace instance. */
+  campus?: string;
   courseFilter: CourseFilterConfig;
 }
 

--- a/src/utils/config-store.ts
+++ b/src/utils/config-store.ts
@@ -13,6 +13,7 @@ export interface ConfigStoreData {
   baseUrl?: string;
   username?: string;
   password?: string;
+  campus?: string;
   sessionDir?: string;
   tokenTtl?: number;
   headless?: boolean;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -59,6 +59,7 @@ export function loadConfig(): AppConfig {
     headless,
     username: process.env.D2L_USERNAME || store?.username,
     password: process.env.D2L_PASSWORD || store?.password,
+    campus: process.env.D2L_CAMPUS || store?.campus,
     courseFilter: {
       includeCourseIds,
       excludeCourseIds,

--- a/tests/auth/purdue-sso-credentials.test.ts
+++ b/tests/auth/purdue-sso-credentials.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { PurdueSSOFlow } from "../../src/auth/purdue-sso.js";
+
+/**
+ * Regression tests for enterCredentials() against Microsoft Entra ID.
+ *
+ * Shibboleth and CAS render the username and password boxes together and one
+ * fill-fill-submit pass completes them. Entra looks the same to a selector but
+ * is not: its account-name page carries a password box that Playwright reports
+ * as visible, while the button only advances to the next view. Filling the
+ * password there and pressing that button leaves the browser parked on the
+ * sign-in page with both fields populated and nothing submitted, while the
+ * flow moves on to wait for an MFA prompt that can never arrive.
+ *
+ * The button label is what separates the two: "Next" on the account-name page,
+ * "Sign in" on the page that follows.
+ */
+
+const USERNAME = "student@example.edu";
+const PASSWORD = "hunter2";
+
+function makeField(visible: boolean, label = "") {
+  return {
+    fill: vi.fn(async () => {}),
+    isVisible: vi.fn(async () => visible),
+    click: vi.fn(async () => {}),
+    press: vi.fn(async () => {}),
+    evaluate: vi.fn(async (fn: (el: unknown) => unknown) =>
+      fn({ value: label, textContent: label }),
+    ),
+  };
+}
+
+/**
+ * Fake Page. With `entra`, it behaves like Microsoft's two-view form: a
+ * password box and a "Next" button up front, replaced by a second password box
+ * and a "Sign in" button once the account name is submitted.
+ */
+function makePage(opts: { entra?: boolean; submitLabel?: string } = {}) {
+  const username = makeField(true);
+  const accountPassword = makeField(true);
+  const signInPassword = makeField(true);
+  const nextButton = makeField(true, "Next");
+  const signInButton = makeField(true, opts.submitLabel ?? "Sign in");
+  let advanced = false;
+
+  nextButton.click = vi.fn(async () => {
+    advanced = true;
+  });
+
+  const matches = (selector: string) => {
+    if (selector.includes("input#username")) return [username];
+    if (selector.includes("input#password")) {
+      if (!opts.entra) return [signInPassword];
+      return advanced ? [signInPassword] : [accountPassword];
+    }
+    if (selector.includes("_eventId_proceed")) {
+      if (!opts.entra) return [signInButton];
+      return [advanced ? signInButton : nextButton];
+    }
+    return [];
+  };
+
+  return {
+    fields: { username, accountPassword, signInPassword, nextButton, signInButton },
+    $: vi.fn(async (selector: string) => matches(selector)[0] ?? null),
+    $$: vi.fn(async (selector: string) => matches(selector)),
+    waitForSelector: vi.fn(async () => null),
+    waitForTimeout: vi.fn(async () => {}),
+    waitForLoadState: vi.fn(async () => {}),
+  };
+}
+
+const enterCredentials = (flow: PurdueSSOFlow, page: unknown): Promise<void> =>
+  (flow as any).enterCredentials(page);
+
+describe("PurdueSSOFlow.enterCredentials", () => {
+  it("submits the account name before entering the password on Entra", async () => {
+    const page = makePage({ entra: true });
+    const flow = new PurdueSSOFlow({ username: USERNAME, password: PASSWORD });
+
+    await enterCredentials(flow, page);
+
+    expect(page.fields.username.fill).toHaveBeenCalledWith(USERNAME);
+    expect(page.fields.nextButton.click).toHaveBeenCalledOnce();
+    // The password belongs to the sign-in view, not the account-name page.
+    expect(page.fields.accountPassword.fill).not.toHaveBeenCalled();
+    expect(page.fields.signInPassword.fill).toHaveBeenCalledWith(PASSWORD);
+    expect(page.fields.signInButton.click).toHaveBeenCalledOnce();
+  });
+
+  it("leaves single-page forms on their existing one-pass path", async () => {
+    const page = makePage({ submitLabel: "Log In" });
+    const flow = new PurdueSSOFlow({ username: USERNAME, password: PASSWORD });
+
+    await enterCredentials(flow, page);
+
+    expect(page.fields.username.fill).toHaveBeenCalledWith(USERNAME);
+    expect(page.fields.signInPassword.fill).toHaveBeenCalledWith(PASSWORD);
+    expect(page.fields.signInButton.click).toHaveBeenCalledOnce();
+    // No account-name hop: the button never said "Next".
+    expect(page.fields.nextButton.click).not.toHaveBeenCalled();
+  });
+
+  it("treats a button labelled Next as an account-name page whatever the case", async () => {
+    const page = makePage({ entra: true });
+    page.fields.nextButton.evaluate = vi.fn(async (fn: (el: unknown) => unknown) =>
+      fn({ value: "NEXT", textContent: "NEXT" }),
+    );
+    const flow = new PurdueSSOFlow({ username: USERNAME, password: PASSWORD });
+
+    await enterCredentials(flow, page);
+
+    expect(page.fields.nextButton.click).toHaveBeenCalledOnce();
+    expect(page.fields.signInButton.click).toHaveBeenCalledOnce();
+  });
+
+  it("still rejects when no password is configured", async () => {
+    const page = makePage();
+    const flow = new PurdueSSOFlow({ username: USERNAME });
+
+    await expect(enterCredentials(flow, page)).rejects.toThrow(/Password is required/);
+  });
+});

--- a/tests/auth/suny-sso.test.ts
+++ b/tests/auth/suny-sso.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi } from "vitest";
+import { SunySSOFlow, isSunyBrightspace } from "../../src/auth/suny-sso.js";
+import { PurdueSSOFlow } from "../../src/auth/purdue-sso.js";
+import { createSSOFlow } from "../../src/auth/sso-flow.js";
+import type { AppConfig } from "../../src/types/index.js";
+
+/**
+ * SUNY campuses share one Brightspace tenant behind one Shibboleth IdP, so a
+ * campus has to be chosen at idm.suny.edu before the campus sign-in form
+ * appears. The configured campus is resolved against SUNY's own dropdown
+ * rather than a copy of the campus table kept here, so the list cannot go
+ * stale. Codes and labels below are the real ones SUNY serves.
+ */
+
+const SUNY_URL = "https://mylearning.suny.edu";
+const IDM_URL = "https://idm.suny.edu/security/login/loginForm.do";
+
+const CAMPUS_OPTIONS: Array<[string, string]> = [
+  ["", "Select Campus..."],
+  ["28010", "Albany"],
+  ["28260", "Purchase"],
+  ["28270", "SUNY Poly"],
+];
+
+function makePage(url: string, options: Array<[string, string]> | null = CAMPUS_OPTIONS) {
+  return {
+    url: vi.fn(() => url),
+    goto: vi.fn(async () => null),
+    waitForSelector: vi.fn(async () => {
+      if (!options) throw new Error("Timeout waiting for campus dropdown");
+      return {};
+    }),
+    $$eval: vi.fn(async (_selector: string, fn: (nodes: unknown[]) => unknown) =>
+      fn((options ?? []).map(([value, label]) => ({ value, textContent: label }))),
+    ),
+    selectOption: vi.fn(async () => []),
+    click: vi.fn(async () => {}),
+  };
+}
+
+const selectCampus = (flow: SunySSOFlow, page: unknown): Promise<void> =>
+  (flow as any).selectCampus(page);
+const startSamlLogin = (flow: SunySSOFlow, page: unknown): Promise<void> =>
+  (flow as any).startSamlLogin(page);
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    baseUrl: SUNY_URL,
+    sessionDir: "/tmp/does-not-matter",
+    tokenTtl: 3600,
+    headless: true,
+    courseFilter: {} as AppConfig["courseFilter"],
+    ...overrides,
+  };
+}
+
+describe("isSunyBrightspace", () => {
+  it("matches the shared SUNY host exactly", () => {
+    expect(isSunyBrightspace(SUNY_URL)).toBe(true);
+    expect(isSunyBrightspace("https://mylearning.suny.edu/d2l/home")).toBe(true);
+  });
+
+  it("does not match other schools or lookalike hosts", () => {
+    expect(isSunyBrightspace("https://purdue.brightspace.com")).toBe(false);
+    // A substring check would wrongly accept this one.
+    expect(isSunyBrightspace("https://mylearning.suny.edu.example.com")).toBe(false);
+    expect(isSunyBrightspace("not a url")).toBe(false);
+  });
+});
+
+describe("createSSOFlow", () => {
+  it("routes the shared SUNY instance to the SUNY flow", () => {
+    expect(createSSOFlow(makeConfig())).toBeInstanceOf(SunySSOFlow);
+  });
+
+  it("leaves every other school on the default flow", () => {
+    const config = makeConfig({ baseUrl: "https://purdue.brightspace.com" });
+    expect(createSSOFlow(config)).toBeInstanceOf(PurdueSSOFlow);
+  });
+});
+
+describe("SunySSOFlow.selectCampus", () => {
+  it.each([
+    ["exact name", "SUNY Poly", "28270"],
+    ["numeric code", "28270", "28270"],
+    ["different casing", "suny poly", "28270"],
+    ["name prefix", "Alb", "28010"],
+  ])("resolves a campus by %s", async (_label, configured, expected) => {
+    const page = makePage(IDM_URL);
+    const flow = new SunySSOFlow({ campus: configured });
+
+    await selectCampus(flow, page);
+
+    expect(page.selectOption).toHaveBeenCalledWith("select#campus", expected);
+    expect(page.click).toHaveBeenCalledOnce();
+  });
+
+  it("leaves the page alone when no campus is configured", async () => {
+    const page = makePage(IDM_URL);
+    const flow = new SunySSOFlow({});
+
+    await selectCampus(flow, page);
+
+    expect(page.selectOption).not.toHaveBeenCalled();
+    expect(page.click).not.toHaveBeenCalled();
+  });
+
+  it("leaves the page alone when the configured campus matches nothing", async () => {
+    const page = makePage(IDM_URL);
+    const flow = new SunySSOFlow({ campus: "Nowhere University" });
+
+    await selectCampus(flow, page);
+
+    expect(page.selectOption).not.toHaveBeenCalled();
+  });
+
+  it("never selects the placeholder option", async () => {
+    const page = makePage(IDM_URL);
+    const flow = new SunySSOFlow({ campus: "Select Campus..." });
+
+    await selectCampus(flow, page);
+
+    expect(page.selectOption).not.toHaveBeenCalled();
+  });
+
+  it("skips the dropdown entirely away from SUNY's identity provider", async () => {
+    const page = makePage("https://login.microsoftonline.com/common/oauth2/authorize");
+    const flow = new SunySSOFlow({ campus: "SUNY Poly" });
+
+    await selectCampus(flow, page);
+
+    expect(page.waitForSelector).not.toHaveBeenCalled();
+  });
+
+  it("is not fooled by SUNY's own host inside a redirect parameter", async () => {
+    // Once the campus is remembered, Microsoft's URL still carries an
+    // idm.suny.edu return address; a substring check would wait here for a
+    // dropdown that is never coming.
+    const page = makePage(
+      "https://login.microsoftonline.com/common/login?redirectUrl=https%3A%2F%2Fidm.suny.edu%2Fidp",
+    );
+    const flow = new SunySSOFlow({ campus: "SUNY Poly" });
+
+    await selectCampus(flow, page);
+
+    expect(page.waitForSelector).not.toHaveBeenCalled();
+  });
+
+  it("continues to the sign-in form when the campus was already remembered", async () => {
+    const page = makePage(IDM_URL, null);
+    const flow = new SunySSOFlow({ campus: "SUNY Poly" });
+
+    await expect(selectCampus(flow, page)).resolves.toBeUndefined();
+    expect(page.selectOption).not.toHaveBeenCalled();
+  });
+});
+
+describe("SunySSOFlow.startSamlLogin", () => {
+  it("bypasses the shadow-DOM campus selector via SUNY's SAML endpoint", async () => {
+    const page = makePage(`${SUNY_URL}/d2l/login?target=%2fd2l%2fhome`);
+    const flow = new SunySSOFlow({});
+
+    await startSamlLogin(flow, page);
+
+    expect(page.goto).toHaveBeenCalledWith(
+      `${SUNY_URL}/d2l/lp/auth/saml/initiate-login?entityId=https://idm.suny.edu/shibboleth/idp/`,
+      expect.objectContaining({ waitUntil: "domcontentloaded" }),
+    );
+  });
+
+  it("does not re-navigate once past the selector", async () => {
+    const page = makePage("https://login.microsoftonline.com/common/oauth2/authorize");
+    const flow = new SunySSOFlow({});
+
+    await startSamlLogin(flow, page);
+
+    expect(page.goto).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds the `--suny` preset described in the README's "Add your school" section, plus the campus handling SUNY needs to reach a sign-in form at all.

**Stacked on #19** — this branch contains that commit, so merging it first shrinks this diff to the SUNY work alone.

## Why SUNY needs a handler, not just a preset

SUNY's campuses share one Brightspace tenant at `mylearning.suny.edu` behind a single Shibboleth IdP, so two pages stand in front of the campus sign-in form:

1. **Brightspace's own campus selector** at `/d2l/login`, whose buttons live in a shadow DOM and cannot be clicked — the same obstacle `handleCampusSelector` already works around for Purdue.
2. **SUNY's campus dropdown** at `idm.suny.edu` — `select#campus[name="selectedCampusCode"]`, 66 options (65 campuses plus a placeholder), submitted by a `LOG IN` button.

On `main`, a run stops at the first of those: `enterCredentials` waits 10s for a username field that the shadow-DOM page never exposes, times out, and drops to manual login.

## What it does

`setup --suny` fills in the shared URL and asks which campus the student attends, stored as an optional `campus` in `config.json`. Blank is fine and omits the key.

At sign-in, `SunySSOFlow` navigates straight to the SAML endpoint the shadow-DOM selector would have reached, answers the campus dropdown, then hands off to the default flow for credentials, MFA and "Stay signed in?" — those are the campus IdP's own pages and need no new handling.

The campus is matched against **SUNY's live option list** rather than a copy of the campus table, by numeric code or by name:

```js
options.find((option) => option.value.toLowerCase() === wanted) ??
options.find((option) => option.label.toLowerCase() === wanted) ??
options.find((option) => option.label.toLowerCase().startsWith(wanted))
```

So there's no 65-row table here to go stale when SUNY renames or adds a campus. With no campus configured, or one that matches nothing, the dropdown is left for the student — who is already at the browser to approve MFA — and the available names are logged.

## Two smaller fixes, both found in testing

**Username format.** The wizard asked for a "username", and a SUNY Poly tester gave the bare campus ID that every other campus system accepts. Entra wants the full sign-in address, and the short form stalls the account-name page. The preset now carries a hint. It's a separate field because `usernameLabel` is reused to build the password prompt by swapping the word "username".

**Duo.** The auth CLI told every user to approve a Duo push regardless of school. SUNY campuses approve through Microsoft, in Outlook or Authenticator, so those lines now name the sign-in request rather than a product the student doesn't have. Purdue's own preset still says Duo.

## The one shared-code change

`BrowserAuth` picked its flow with a hardcoded `new PurdueSSOFlow(...)`, so there was no way to register the handler the README invites contributors to add. It now calls `createSSOFlow(config)` — a hostname check and two branches:

```js
export function createSSOFlow(config: AppConfig): SSOFlow {
  const credentials = { username: config.username, password: config.password };
  if (isSunyBrightspace(config.baseUrl)) {
    return new SunySSOFlow({ ...credentials, campus: config.campus });
  }
  return new PurdueSSOFlow(credentials);
}
```

Every school other than SUNY keeps the existing flow. `PurdueSSOFlow` is untouched apart from its opening log line, which announced Purdue to schools that aren't Purdue. `SunySSOFlow` composes that flow rather than duplicating or subclassing it, so credential, MFA and KMSI logic stays in one place.

## Tests

New `tests/auth/suny-sso.test.ts`, 16 cases, no browser:

| Group | Covers |
|---|---|
| `isSunyBrightspace` | exact host match; rejects `mylearning.suny.edu.example.com` and non-URLs |
| `createSSOFlow` | SUNY routes to `SunySSOFlow`, everything else to `PurdueSSOFlow` |
| campus matching | exact name, numeric code, mixed case, name prefix |
| campus fallbacks | none configured, no match, placeholder never selected |
| dropdown skipping | skips away from SUNY's IdP; not fooled by `idm.suny.edu` inside a redirect parameter; continues when the campus was already remembered |
| SAML bypass | correct `entityId`; no re-navigation once past the selector |

Full suite: 82 passed (9 files), `tsc` clean.

## Verification

A live, untouched sign-in on a SUNY Poly account:

```
[INFO] Navigating to https://mylearning.suny.edu/d2l/home
[INFO] Login required (redirected to .../d2l/login?sessionExpired=0&target=%2fd2l%2fhome)
[INFO] Campus selector detected — navigating directly to SUNY's SAML endpoint
[INFO] Selecting campus SUNY Poly (28270)
[INFO] Entering credentials
[INFO] Account-name page detected — submitting account name
[INFO] MFA completed — redirected to: ...
[INFO] Login successful - reached Brightspace home
[INFO] Extracted valid Bearer token from localStorage
[INFO] Authentication complete
```

No interaction with the browser at any point; the only manual step was approving the push. A second run reused the stored session and skipped login entirely. The wizard was also exercised for `--suny` with and without a campus, and for `--purdue`, whose output is unchanged.

## Notes

- **No version bump**, same reason as #19 — `main` (1.2.8) is ahead of npm (1.2.6).
- `docs/how-it-works.svg` unchanged: this adds a school, it doesn't change how the system works.
- README, `LLMs.md` and the `AGENTS.md` architecture note are updated, including the `createSSOFlow` step in "Adding a school".
- `--suny` covers campuses on the shared `mylearning.suny.edu` instance; a few SUNY schools self-host Brightspace elsewhere and still want the plain `setup` path. Campuses whose IdP isn't Microsoft — Albany, for one — get the campus steps automated and then fall back to the normal flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
