### PR TITLE
Support headless MFA code entry

### DIFF
--- a/LLMs.md
+++ b/LLMs.md
@@ -46,7 +46,7 @@ npx brightspace-mcp-server setup --suny
 The wizard:
 
 - prompts for the school's Brightspace URL (skipped with `--purdue` or `--suny`)
-- runs a headless Chromium login and prints Microsoft Authenticator number matches in the terminal
+- asks whether MFA can run in the background or needs a visible browser, then authenticates accordingly
 - saves the password in the native credential store and public settings in `~/.brightspace-mcp/config.json` (0600)
 - writes the encrypted session below `~/.d2l-session/accounts/<account-hash>/` (AES-256-GCM)
 - auto-configures Claude Desktop and Cursor if detected
@@ -71,7 +71,7 @@ Tell the user to fully quit and reopen their AI client so it picks up the new MC
 
 ## Re-auth
 
-Access tokens are re-minted from the stored session cookie without a browser. A headless browser restores encrypted state for silent SSO when required, then enters saved credentials if Microsoft needs a full login. Missed MFA pauses automatic browser authentication, including SSO redirects, for four hours to prevent repeated phone prompts. HTTP token renewal remains allowed; the explicit command below bypasses the browser cooldown. Forward the MFA number to the user as it appears and wait for phone approval. Clients may hide server logs, so a terminal is the reliable place to see the number. Network errors and locked native storage should be reported without retrying MFA.
+Access tokens are re-minted from the stored session cookie without a browser. When browser authentication is required, setup's MFA choice controls whether Chromium stays hidden for approval-based MFA or opens for code entry and other interaction. Missed MFA pauses automatic browser authentication, including SSO redirects, for four hours to prevent repeated phone prompts. HTTP token renewal remains allowed; the explicit command below bypasses the browser cooldown. Forward any MFA number to the user as it appears and wait for completion. Clients may hide server logs, so a terminal is the reliable place to see the number. Network errors and locked native storage should be reported without retrying MFA.
 
 ```bash
 npx brightspace-mcp-server auth

--- a/LLMs.md
+++ b/LLMs.md
@@ -46,7 +46,7 @@ npx brightspace-mcp-server setup --suny
 The wizard:
 
 - prompts for the school's Brightspace URL (skipped with `--purdue` or `--suny`)
-- asks whether MFA can run in the background or needs a visible browser, then authenticates accordingly
+- asks whether MFA uses device approval, terminal code entry, or a visible browser, then authenticates accordingly
 - saves the password in the native credential store and public settings in `~/.brightspace-mcp/config.json` (0600)
 - writes the encrypted session below `~/.d2l-session/accounts/<account-hash>/` (AES-256-GCM)
 - auto-configures Claude Desktop and Cursor if detected
@@ -71,7 +71,7 @@ Tell the user to fully quit and reopen their AI client so it picks up the new MC
 
 ## Re-auth
 
-Access tokens are re-minted from the stored session cookie without a browser. When browser authentication is required, setup's MFA choice controls whether Chromium stays hidden for approval-based MFA or opens for code entry and other interaction. Missed MFA pauses automatic browser authentication, including SSO redirects, for four hours to prevent repeated phone prompts. HTTP token renewal remains allowed; the explicit command below bypasses the browser cooldown. Forward any MFA number to the user as it appears and wait for completion. Clients may hide server logs, so a terminal is the reliable place to see the number. Network errors and locked native storage should be reported without retrying MFA.
+Access tokens are re-minted from the stored session cookie without a browser. When browser authentication is required, setup's MFA choice controls whether Chromium stays hidden for approval or terminal code entry, or opens for other interaction. Automatic MCP authentication cannot read a code from stdio; tell the user to run the explicit command below, which prompts without echoing the code into MCP logs. Missed approval pauses automatic browser authentication for four hours. HTTP token renewal remains allowed, and the explicit command bypasses the cooldown. Network errors and locked native storage should be reported without retrying MFA.
 
 ```bash
 npx brightspace-mcp-server auth

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ you're at and skips SUNY's campus picker when you sign in:
 npx brightspace-mcp-server setup --suny
 ```
 
-The wizard saves your password in the native credential store and asks how you complete MFA. Choose background authentication for approval or number matching, or visible-browser authentication when you must enter a code from Google Authenticator, SMS, email, or another source. The wizard can configure Claude Desktop and Cursor. Restart your AI client when it finishes.
+The wizard saves your password in the native credential store and asks how you complete MFA. Authentication can wait for approval or number matching, prompt in the terminal for a code from Google Authenticator or another app, or open a visible browser for other interactive methods. The wizard can configure Claude Desktop and Cursor. Restart your AI client when it finishes.
 
 Any other D2L school: run `setup` without a flag and paste your Brightspace URL (for example `https://yourschool.brightspace.com`).
 
@@ -71,17 +71,17 @@ You still need to run `npx brightspace-mcp-server setup` first to save your cred
 
 ## Session Expired?
 
-Returning the next day normally requires no action. The server renews short-lived API tokens over HTTPS using the saved Brightspace session. If that session ends, a browser restores your saved Microsoft session and tries silent SSO. It stays hidden for approval-based MFA and opens when setup is configured for interactive MFA.
+Returning the next day normally requires no action. The server renews short-lived API tokens over HTTPS using the saved Brightspace session. If that session ends, a browser restores your saved Microsoft session and tries silent SSO. Approval and code-based modes stay headless; when an automatic run needs a code, run the auth command below to enter it securely in the terminal.
 
 Your school's policy controls when MFA is required. There is no local 24-hour cutoff, and the server no longer discards browser state after one hour. A network outage preserves the saved session and returns a temporary error.
 
-If you miss an MFA request, automatic browser authentication waits four hours before trying again. Existing tokens and HTTP token renewal still work. Browser-based SSO also pauses because Microsoft can send another phone prompt during a redirect, even without a password submission. Run this command in a terminal to retry immediately and see the MFA number:
+If you miss an MFA request, automatic browser authentication waits four hours before trying again. Existing tokens and HTTP token renewal still work. Browser-based SSO also pauses because Microsoft can send another phone prompt during a redirect, even without a password submission. Run this command in a terminal to retry immediately, see a number match, or enter an authenticator code:
 
 ```bash
 npx brightspace-mcp-server auth
 ```
 
-**MFA at Purdue** commonly uses Microsoft Authenticator number matching: enter the terminal-displayed number on your phone. If your account instead requires a code or another browser interaction, rerun setup and choose option 2. The MCP also sends authentication progress as logging notifications to clients that display them. Some desktop clients hide server logs, so use the terminal command above if the number is not visible.
+**MFA at Purdue** commonly uses Microsoft Authenticator number matching: enter the terminal-displayed number on your phone. For Google Authenticator or another one-time-code app, rerun setup and choose option 2; choose option 3 only when the identity provider requires browser interaction. The MCP also sends authentication progress as logging notifications to clients that display them. Some desktop clients hide server logs, so use the terminal command above for interactive MFA.
 
 ## What You Can Ask About
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ you're at and skips SUNY's campus picker when you sign in:
 npx brightspace-mcp-server setup --suny
 ```
 
-The wizard saves your password in the native credential store and runs login in a headless browser. At Purdue, approve Microsoft Authenticator using the number printed in the terminal. No browser window opens. The wizard can configure Claude Desktop and Cursor. Restart your AI client when it finishes.
+The wizard saves your password in the native credential store and asks how you complete MFA. Choose background authentication for approval or number matching, or visible-browser authentication when you must enter a code from Google Authenticator, SMS, email, or another source. The wizard can configure Claude Desktop and Cursor. Restart your AI client when it finishes.
 
 Any other D2L school: run `setup` without a flag and paste your Brightspace URL (for example `https://yourschool.brightspace.com`).
 
@@ -71,7 +71,7 @@ You still need to run `npx brightspace-mcp-server setup` first to save your cred
 
 ## Session Expired?
 
-Returning the next day normally requires no action. The server renews short-lived API tokens over HTTPS using the saved Brightspace session. If that session ends, a headless browser restores your saved Microsoft session and tries silent SSO. If Microsoft requires sign-in, your saved credentials are entered automatically and you complete MFA on your phone.
+Returning the next day normally requires no action. The server renews short-lived API tokens over HTTPS using the saved Brightspace session. If that session ends, a browser restores your saved Microsoft session and tries silent SSO. It stays hidden for approval-based MFA and opens when setup is configured for interactive MFA.
 
 Your school's policy controls when MFA is required. There is no local 24-hour cutoff, and the server no longer discards browser state after one hour. A network outage preserves the saved session and returns a temporary error.
 
@@ -81,7 +81,7 @@ If you miss an MFA request, automatic browser authentication waits four hours be
 npx brightspace-mcp-server auth
 ```
 
-**MFA at Purdue** is Microsoft Authenticator number matching: enter the terminal-displayed number on your phone. The MCP also sends authentication progress as logging notifications to clients that display them. Some desktop clients hide server logs, so use the terminal command above if the number is not visible. Unsupported identity-provider pages require a supported sign-in handler; the server does not silently open a visible browser.
+**MFA at Purdue** commonly uses Microsoft Authenticator number matching: enter the terminal-displayed number on your phone. If your account instead requires a code or another browser interaction, rerun setup and choose option 2. The MCP also sends authentication progress as logging notifications to clients that display them. Some desktop clients hide server logs, so use the terminal command above if the number is not visible.
 
 ## What You Can Ask About
 

--- a/server.json
+++ b/server.json
@@ -32,7 +32,7 @@
         },
         {
           "name": "D2L_HEADLESS",
-          "description": "Deprecated compatibility setting. Authentication in v2 always runs headlessly. MFA number matches are printed in the terminal.",
+          "description": "Run browser authentication without a visible window. Set false for code-entry or other interactive MFA methods. Default: true",
           "isRequired": false,
           "format": "boolean",
           "isSecret": false

--- a/server.json
+++ b/server.json
@@ -32,7 +32,7 @@
         },
         {
           "name": "D2L_HEADLESS",
-          "description": "Run browser authentication without a visible window. Set false for code-entry or other interactive MFA methods. Default: true",
+          "description": "Run browser authentication without a visible window. Set false only for MFA methods that require browser interaction. Default: true",
           "isRequired": false,
           "format": "boolean",
           "isSecret": false

--- a/src/auth-cli.ts
+++ b/src/auth-cli.ts
@@ -18,7 +18,9 @@ async function main(): Promise<void> {
   try {
     const config = await loadConfig();
     console.error(`\n=== Brightspace Authentication v${pkg.version} ===\n`);
-    console.error("Authentication runs headlessly. If Microsoft requests MFA, the number appears here.");
+    console.error(config.headless
+      ? "Authentication runs headlessly. If Microsoft requests MFA, the number appears here."
+      : "Authentication opens a browser so you can complete MFA in the sign-in page.");
 
     const tokenManager = new TokenManager({
       sessionDir: config.sessionDir,

--- a/src/auth-cli.ts
+++ b/src/auth-cli.ts
@@ -4,6 +4,7 @@
 import { readFileSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline/promises";
 import dotenv from "dotenv";
 import { loadConfig } from "./utils/config.js";
 import { BrowserAuth, TokenManager } from "./auth/index.js";
@@ -13,13 +14,26 @@ import { retireLegacyProfile } from "./auth/legacy-profile.js";
 dotenv.config({ quiet: true });
 const pkg = JSON.parse(readFileSync(path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "package.json"), "utf8"));
 
+async function requestMfaCode(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    while (true) {
+      const code = (await rl.question("Enter the code from your authenticator app: ")).replace(/\s/g, "");
+      if (/^\d{6,8}$/.test(code)) return code;
+      console.error("Enter the 6-8 digit code shown by your authenticator app.");
+    }
+  } finally {
+    rl.close();
+  }
+}
+
 async function main(): Promise<void> {
   const automatic = process.argv.includes("--automatic");
   try {
     const config = await loadConfig();
     console.error(`\n=== Brightspace Authentication v${pkg.version} ===\n`);
     console.error(config.headless
-      ? "Authentication runs headlessly. If Microsoft requests MFA, the number appears here."
+      ? "Authentication runs headlessly. MFA numbers and code prompts appear here."
       : "Authentication opens a browser so you can complete MFA in the sign-in page.");
 
     const tokenManager = new TokenManager({
@@ -27,7 +41,8 @@ async function main(): Promise<void> {
       baseUrl: config.baseUrl,
       tokenTtl: config.tokenTtl,
     });
-    await new BrowserAuth(config).authenticate({
+    const codePrompt = config.headless && !automatic && process.stdin.isTTY ? requestMfaCode : undefined;
+    await new BrowserAuth(config, codePrompt).authenticate({
       automatic,
       onAuthenticated: async (token) => {
         await tokenManager.setToken(token);

--- a/src/auth/browser-auth.ts
+++ b/src/auth/browser-auth.ts
@@ -104,7 +104,7 @@ export class BrowserAuth {
       const args = ["--disable-blink-features=AutomationControlled"];
       if (BrowserAuth.isWSLOrDocker()) args.push("--no-sandbox", "--disable-setuid-sandbox");
       // Use Playwright's own timeout, which cleans up an unsuccessful launch.
-      browser = await chromium.launch({ headless: true, timeout: 60000, args });
+      browser = await chromium.launch({ headless: this.config.headless, timeout: 60000, args });
       process.once("SIGINT", closeOnSignal);
       process.once("SIGTERM", closeOnSignal);
       context = await browser.newContext({ viewport: { width: 1280, height: 720 }, storageState: state });

--- a/src/auth/browser-auth.ts
+++ b/src/auth/browser-auth.ts
@@ -140,7 +140,7 @@ export class BrowserAuth {
       }
       if (!token) throw new BrowserAuthError("Brightspace did not provide a usable API token. Saved SSO cookies have been preserved.", "token_extraction");
       if (interrupted) throw new BrowserAuthError("Authentication interrupted", "interrupted");
-      log("INFO", "Headless authentication complete");
+      log("INFO", "Browser authentication complete");
       return { ...token, ...material, tenantOrigin: new URL(this.config.baseUrl).origin };
     } finally {
       process.removeListener("SIGINT", closeOnSignal);

--- a/src/auth/browser-auth.ts
+++ b/src/auth/browser-auth.ts
@@ -12,6 +12,7 @@ import { BrowserAuthError } from "../utils/errors.js";
 import { log } from "../utils/logger.js";
 import { createSSOFlow, UnsupportedAuthenticationError, MfaApprovalError } from "./sso-flow.js";
 import type { SSOFlow } from "./sso-flow.js";
+import type { RequestMfaCode } from "./sso-flow.js";
 import { BrowserStateStore } from "./browser-state-store.js";
 import { acquireProcessLock } from "./auth-lock.js";
 import { AuthCooldown } from "./auth-cooldown.js";
@@ -50,9 +51,9 @@ export class BrowserAuth {
   private readonly stateStore: BrowserStateStore;
   private readonly cooldown: AuthCooldown;
 
-  constructor(config: AppConfig) {
+  constructor(config: AppConfig, requestMfaCode?: RequestMfaCode) {
     this.config = config;
-    this.ssoFlow = createSSOFlow(config);
+    this.ssoFlow = createSSOFlow(config, requestMfaCode);
     this.stateStore = new BrowserStateStore(config.sessionDir);
     this.cooldown = new AuthCooldown(config.sessionDir);
   }

--- a/src/auth/purdue-sso.ts
+++ b/src/auth/purdue-sso.ts
@@ -8,6 +8,7 @@ import type { Locator, Page } from "playwright";
 import { BrowserAuthError } from "../utils/errors.js";
 import { log } from "../utils/logger.js";
 import { MfaApprovalError, UnsupportedAuthenticationError } from "./sso-flow.js";
+import type { RequestMfaCode } from "./sso-flow.js";
 
 const EMAIL_SELECTORS = ["input[type=email]", "input[name=loginfmt]"];
 const PASSWORD_SELECTORS = ["input[type=password]", "input[name=passwd]"];
@@ -22,6 +23,8 @@ const FIELD_POLL_MS = 250;
  * logged. Plain DOM text, no OCR.
  */
 const NUMBER_MATCH_SELECTOR = "#idRichContext_DisplaySign";
+const MFA_CODE_SELECTORS = ["#idTxtBx_SAOTCC_OTC", 'input[name="otc"]'];
+const MFA_CODE_SUBMIT_SELECTORS = ["#idSubmit_SAOTCC_Continue", "#idSIButton9"];
 
 /** How often to look for the number while waiting on MFA. */
 const NUMBER_MATCH_POLL_MS = 2000;
@@ -33,6 +36,8 @@ interface PurdueSSOConfig {
   username?: string;
   password?: string;
   baseUrl?: string;
+  headless?: boolean;
+  requestMfaCode?: RequestMfaCode;
 }
 
 /** Microsoft expects Purdue's full sign-in name, while setup also accepts a career account. */
@@ -193,6 +198,7 @@ export class PurdueSSOFlow {
     let announced: string | null = null;
     try {
       while (Date.now() < deadline) {
+        if (await this.submitMfaCode(page)) challenged = true;
         const number = await this.readNumberMatch(page);
         const challengeVisible = number !== null ||
           await page.locator("#idDiv_SAOTCAS_Title").first().isVisible().catch(() => false) ||
@@ -213,11 +219,39 @@ export class PurdueSSOFlow {
         await page.waitForTimeout(NUMBER_MATCH_POLL_MS);
       }
     } catch (error) {
+      if (error instanceof BrowserAuthError) throw error;
       if (challenged) throw new MfaApprovalError(error as Error);
       throw new UnsupportedAuthenticationError("Headless sign-in stopped before a supported MFA challenge completed.", error as Error);
     }
     if (challenged) throw new MfaApprovalError();
     throw new UnsupportedAuthenticationError("Sign-in did not reach a supported MFA challenge or Brightspace within 5 minutes.");
+  }
+
+  private async submitMfaCode(page: Page): Promise<boolean> {
+    const input = await this.firstVisible(page, MFA_CODE_SELECTORS);
+    if (!input) return false;
+    if (this.config.headless === false) return false;
+    if (!this.config.requestMfaCode) {
+      throw new UnsupportedAuthenticationError(
+        "This MFA method requires a code. Run `npx brightspace-mcp-server auth` in a terminal to enter it.",
+      );
+    }
+    const code = await this.config.requestMfaCode();
+    if (!/^\d{6,8}$/.test(code)) throw new UnsupportedAuthenticationError("The MFA code must contain 6-8 digits.");
+    await input.fill(code);
+    const submit = await this.firstVisible(page, MFA_CODE_SUBMIT_SELECTORS);
+    if (submit) await submit.click();
+    else await input.press("Enter");
+    log("INFO", "Authenticator code submitted");
+    return true;
+  }
+
+  private async firstVisible(page: Page, selectors: readonly string[]): Promise<Locator | null> {
+    for (const selector of selectors) {
+      const target = page.locator(selector).first();
+      if (await target.isVisible().catch(() => false)) return target;
+    }
+    return null;
   }
 
   /** The login shell also exposes D2L.LP, so verify origin and home as well. */

--- a/src/auth/sso-flow.ts
+++ b/src/auth/sso-flow.ts
@@ -10,6 +10,8 @@ import { PurdueSSOFlow } from "./purdue-sso.js";
 import { SunySSOFlow, isSunyBrightspace } from "./suny-sso.js";
 import { BrowserAuthError } from "../utils/errors.js";
 
+export type RequestMfaCode = () => Promise<string>;
+
 export class UnsupportedAuthenticationError extends BrowserAuthError {
   readonly code = "AUTH_UNSUPPORTED";
   constructor(message: string, cause?: Error) {
@@ -44,8 +46,14 @@ export interface SSOFlow {
  * else uses the default flow, which already covers the common Shibboleth,
  * CAS, and Microsoft Entra forms.
  */
-export function createSSOFlow(config: AppConfig): SSOFlow {
-  const credentials = { username: config.username, password: config.password, baseUrl: config.baseUrl };
+export function createSSOFlow(config: AppConfig, requestMfaCode?: RequestMfaCode): SSOFlow {
+  const credentials = {
+    username: config.username,
+    password: config.password,
+    baseUrl: config.baseUrl,
+    headless: config.headless,
+    requestMfaCode,
+  };
 
   if (isSunyBrightspace(config.baseUrl)) {
     return new SunySSOFlow({ ...credentials, campus: config.campus });

--- a/src/auth/suny-sso.ts
+++ b/src/auth/suny-sso.ts
@@ -8,6 +8,7 @@ import type { Page } from "playwright";
 import { PurdueSSOFlow } from "./purdue-sso.js";
 import { log } from "../utils/logger.js";
 import { UnsupportedAuthenticationError } from "./sso-flow.js";
+import type { RequestMfaCode } from "./sso-flow.js";
 
 /** SUNY campuses share one Brightspace tenant behind one Shibboleth IdP. */
 const SUNY_BRIGHTSPACE_HOST = "mylearning.suny.edu";
@@ -24,6 +25,8 @@ interface SunySSOConfig {
   password?: string;
   /** Campus name or numeric code, matched against SUNY's own dropdown. */
   campus?: string;
+  headless?: boolean;
+  requestMfaCode?: RequestMfaCode;
 }
 
 interface CampusOption {
@@ -71,6 +74,8 @@ export class SunySSOFlow {
       username: config.username,
       password: config.password,
       baseUrl: `https://${SUNY_BRIGHTSPACE_HOST}`,
+      headless: config.headless,
+      requestMfaCode: config.requestMfaCode,
     });
   }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -11,7 +11,7 @@ import * as readline from "node:readline";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { getConfigStorePath } from "./utils/config-store.js";
 import { saveSecureConfig } from "./utils/secure-config.js";
@@ -265,20 +265,16 @@ function runAuth(): Promise<boolean> {
   const scriptPath = path.resolve(thisDir, "auth-cli.js");
 
   return new Promise((resolve) => {
-    const child = execFile(
+    const child = spawn(
       process.execPath,
       [scriptPath],
       {
-        timeout: 8 * 60 * 1000,
         env: { ...process.env },
-      },
-      (error) => {
-        resolve(!error);
+        stdio: "inherit",
       },
     );
-    // Pipe child output so the user sees the auth flow
-    child.stdout?.pipe(process.stdout);
-    child.stderr?.pipe(process.stderr);
+    child.once("error", () => resolve(false));
+    child.once("close", (code) => resolve(code === 0));
   });
 }
 
@@ -379,7 +375,7 @@ async function main(): Promise<void> {
   console.log("");
 
   // Re-open readline for remaining prompts
-  const rl2 = readline.createInterface({
+  let rl2 = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
@@ -393,13 +389,14 @@ async function main(): Promise<void> {
   console.log("");
   console.log("  How do you complete MFA?");
   console.log("    1. Approve a notification or enter a displayed number on another device");
-  console.log("    2. Enter a code or complete another step in the sign-in page");
+  console.log("    2. Enter a code from an authenticator app in this terminal");
+  console.log("    3. Complete MFA in a visible browser window");
   let mfaChoice = "";
-  while (!/^[12]$/.test(mfaChoice)) {
-    mfaChoice = await ask(rl2, "  Choose 1 or 2 [1]: ") || "1";
-    if (!/^[12]$/.test(mfaChoice)) console.log(yellow("  Please enter 1 or 2."));
+  while (!/^[123]$/.test(mfaChoice)) {
+    mfaChoice = await ask(rl2, "  Choose 1, 2, or 3 [1]: ") || "1";
+    if (!/^[123]$/.test(mfaChoice)) console.log(yellow("  Please enter 1, 2, or 3."));
   }
-  const headless = mfaChoice === "1";
+  const headless = mfaChoice !== "3";
   console.log(dim(headless
     ? "  Authentication will run without a browser window."
     : "  A browser window will open when authentication is needed."));
@@ -424,10 +421,12 @@ async function main(): Promise<void> {
   // ── Step 6: Authenticate now? ────────────────────────────────────
   const authNow = await ask(rl2, "Would you like to authenticate now? (yes/no): ");
   if (/^y(es)?$/i.test(authNow)) {
+    rl2.close();
     console.log("");
     console.log(dim("  Starting authentication..."));
     console.log("");
     const ok = await runAuth();
+    rl2 = readline.createInterface({ input: process.stdin, output: process.stdout });
     if (ok) {
       console.log(green("\n  Authentication successful!"));
     } else {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -43,7 +43,7 @@ const SCHOOL_PRESETS: Record<string, SchoolPreset> = {
     name: "Purdue University",
     baseUrl: "https://purdue.brightspace.com",
     usernameLabel: "Purdue career account username or full email",
-    mfaNote: "Approve the sign-in in Microsoft Authenticator. The number is printed here; no browser window opens.",
+    mfaNote: "Microsoft Authenticator number matching can run without a browser window.",
   },
   suny: {
     name: "SUNY",
@@ -391,12 +391,26 @@ async function main(): Promise<void> {
     console.log(dim("  MFA: You will be prompted to approve the sign-in on your phone during auth."));
   }
   console.log("");
+  console.log("  How do you complete MFA?");
+  console.log("    1. Approve a notification or enter a displayed number on another device");
+  console.log("    2. Enter a code or complete another step in the sign-in page");
+  let mfaChoice = "";
+  while (!/^[12]$/.test(mfaChoice)) {
+    mfaChoice = await ask(rl2, "  Choose 1 or 2 [1]: ") || "1";
+    if (!/^[12]$/.test(mfaChoice)) console.log(yellow("  Please enter 1 or 2."));
+  }
+  const headless = mfaChoice === "1";
+  console.log(dim(headless
+    ? "  Authentication will run without a browser window."
+    : "  A browser window will open when authentication is needed."));
+  console.log("");
 
   // ── Step 5: Save config ──────────────────────────────────────────
   const config: ConfigStoreData = {
     baseUrl,
     username,
     password,
+    headless,
   };
   if (campus) {
     config.campus = campus;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -30,8 +30,10 @@ export async function loadConfig(): Promise<AppConfig> {
       ? expandTilde(store.sessionDir)
       : path.join(os.homedir(), ".d2l-session");
 
-  // Authentication always runs without a visible browser in v2.
-  const headless = true;
+  // Code-entry and other interactive MFA methods need a visible browser.
+  const headless = process.env.D2L_HEADLESS !== undefined
+    ? process.env.D2L_HEADLESS !== "false"
+    : store?.headless ?? true;
 
   // Resolve tokenTtl: env > store > default (3600)
   const tokenTtl = process.env.D2L_TOKEN_TTL

--- a/tests/auth/headless-login-visibility.test.ts
+++ b/tests/auth/headless-login-visibility.test.ts
@@ -44,11 +44,11 @@ beforeEach(async () => {
 
 afterEach(() => { vi.restoreAllMocks(); });
 
-describe("headless BrowserAuth lifecycle", () => {
-  it("always launches an ephemeral headless context and restores state without checking its age", async () => {
+describe("BrowserAuth lifecycle", () => {
+  it("honors the configured browser visibility and restores state without checking its age", async () => {
     const onAuthenticated = vi.fn(async () => {});
     await expect(auth.authenticate({ onAuthenticated })).resolves.toEqual(token);
-    expect(mocks.launch).toHaveBeenCalledWith(expect.objectContaining({ headless: true, timeout: 60000 }));
+    expect(mocks.launch).toHaveBeenCalledWith(expect.objectContaining({ headless: false, timeout: 60000 }));
     expect(browser.newContext).toHaveBeenCalledWith(expect.objectContaining({ storageState: await mocks.load.mock.results[0].value }));
     expect(context.storageState).toHaveBeenCalledWith();
     expect(mocks.save).toHaveBeenCalledWith({ cookies: [], origins: [] });

--- a/tests/auth/purdue-sso-mfa.test.ts
+++ b/tests/auth/purdue-sso-mfa.test.ts
@@ -7,6 +7,7 @@ const SIGN_SELECTOR = "#idRichContext_DisplaySign";
 
 interface PollState {
   number?: string;
+  code?: boolean;
   challenge?: boolean;
   kmsi?: boolean;
   url?: string;
@@ -27,16 +28,22 @@ function captureWarnings() {
 function makeMfaPage(states: PollState[]) {
   let poll = 0;
   const yes = vi.fn(async () => {});
+  const fill = vi.fn(async () => {});
+  const press = vi.fn(async () => {});
   const current = () => states[Math.min(poll, states.length - 1)] ?? {};
   const locatorTarget = (selector: string) => ({
     isVisible: async () => {
       if (selector === SIGN_SELECTOR) return current().number !== undefined;
-      if (selector === "#idDiv_SAOTCAS_Title" || selector === "#idDiv_SAOTCC_Title") return Boolean(current().challenge);
+      if (selector === "#idTxtBx_SAOTCC_OTC" || selector === 'input[name="otc"]') return Boolean(current().code);
+      if (selector === "#idSubmit_SAOTCC_Continue") return Boolean(current().code);
+      if (selector === "#idDiv_SAOTCAS_Title" || selector === "#idDiv_SAOTCC_Title") return Boolean(current().challenge || current().code);
       if (selector === "#KmsiCheckboxField" || selector === "#idSIButton9") return Boolean(current().kmsi);
       return false;
     },
     textContent: async () => selector === SIGN_SELECTOR ? current().number ?? null : null,
     click: yes,
+    fill,
+    press,
   });
   const page = {
     url: vi.fn(() => current().url ?? "https://login.microsoftonline.com/common/SAS/BeginAuth"),
@@ -51,7 +58,7 @@ function makeMfaPage(states: PollState[]) {
       vi.advanceTimersByTime(milliseconds);
     }),
   };
-  return { page, yes, poll: () => poll };
+  return { page, yes, fill, press, poll: () => poll };
 }
 
 describe("Purdue MFA loop ported from Brightspace Bar", () => {
@@ -64,8 +71,8 @@ describe("Purdue MFA loop ported from Brightspace Bar", () => {
     vi.restoreAllMocks();
   });
 
-  const handleMFA = (page: unknown): Promise<void> =>
-    (new PurdueSSOFlow({ baseUrl: BASE_URL }) as any).handleMFA(page);
+  const handleMFA = (page: unknown, requestMfaCode?: () => Promise<string>): Promise<void> =>
+    (new PurdueSSOFlow({ baseUrl: BASE_URL, requestMfaCode }) as any).handleMFA(page);
 
   it("logs a number once per change and stops only at verified Brightspace home", async () => {
     const lines = captureWarnings();
@@ -89,6 +96,33 @@ describe("Purdue MFA loop ported from Brightspace Bar", () => {
     ]);
     await handleMFA(page);
     expect(yes).toHaveBeenCalledOnce();
+  });
+
+  it("submits an authenticator code without exposing it in logs", async () => {
+    const requestMfaCode = vi.fn(async () => "123456");
+    const { page, fill, yes } = makeMfaPage([
+      { code: true },
+      { url: `${BASE_URL}/d2l/home`, cookie: true, d2l: true },
+    ]);
+    await handleMFA(page, requestMfaCode);
+    expect(requestMfaCode).toHaveBeenCalledOnce();
+    expect(fill).toHaveBeenCalledWith("123456");
+    expect(yes).toHaveBeenCalledOnce();
+  });
+
+  it("directs non-interactive authentication to the CLI when a code is required", async () => {
+    const { page, poll } = makeMfaPage([{ code: true }]);
+    await expect(handleMFA(page)).rejects.toThrow("Run `npx brightspace-mcp-server auth`");
+    expect(poll()).toBe(0);
+  });
+
+  it("leaves code entry to the user when the browser is visible", async () => {
+    const { page, fill } = makeMfaPage([
+      { code: true },
+      { url: `${BASE_URL}/d2l/home`, cookie: true, d2l: true },
+    ]);
+    await (new PurdueSSOFlow({ baseUrl: BASE_URL, headless: false }) as any).handleMFA(page);
+    expect(fill).not.toHaveBeenCalled();
   });
 
   it("rejects the login shell even when it has a cookie and D2L.LP", async () => {

--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as path from "node:path";
 
-const fake = vi.hoisted(() => ({ dotenv: vi.fn(), password: vi.fn(), migrate: vi.fn() }));
+const fake = vi.hoisted(() => ({
+  dotenv: vi.fn(), password: vi.fn(), migrate: vi.fn(),
+  store: null as Record<string, unknown> | null,
+}));
 vi.mock("dotenv", () => ({ default: { config: fake.dotenv } }));
-vi.mock("../../src/utils/config-store.js", () => ({ configStoreExists: () => false, loadConfigStore: vi.fn() }));
+vi.mock("../../src/utils/config-store.js", () => ({
+  configStoreExists: () => fake.store !== null,
+  loadConfigStore: () => fake.store,
+}));
 vi.mock("../../src/utils/secure-config.js", () => ({ resolveStoredPassword: fake.password }));
 vi.mock("../../src/auth/legacy-state.js", () => ({ migrateLegacyState: fake.migrate }));
 import { accountSessionDirectory, loadConfig } from "../../src/utils/config.js";
@@ -12,6 +18,7 @@ describe("resolved authentication configuration", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     for (const key of Object.keys(process.env).filter(key => key.startsWith("D2L_"))) vi.stubEnv(key, undefined);
+    fake.store = null;
     fake.password.mockResolvedValue("native-password");
     fake.migrate.mockResolvedValue({ tokenState: "absent", browserState: "encrypted" });
   });
@@ -28,12 +35,17 @@ describe("resolved authentication configuration", () => {
     const config = await loadConfig();
     expect(config).toMatchObject({
       baseUrl: "https://school.example", username: "alice", password: "native-password",
-      sessionRoot: root, sessionDir: accountSessionDirectory(root, "https://school.example", "alice"), headless: true,
+      sessionRoot: root, sessionDir: accountSessionDirectory(root, "https://school.example", "alice"), headless: false,
     });
     expect(fake.dotenv).toHaveBeenCalledWith({ quiet: true });
     expect(fake.password).toHaveBeenCalledWith("https://school.example", "alice", null);
     expect(fake.migrate).toHaveBeenCalledWith(root);
     expect(config.legacyBrowserStateMigrated).toBe(true);
+  });
+
+  it("uses the setup MFA preference when no environment override is present", async () => {
+    fake.store = { baseUrl: "https://school.example", username: "alice", headless: false };
+    expect(await loadConfig()).toMatchObject({ headless: false });
   });
 
   it("rejects credential-bearing URLs before accessing native storage", async () => {


### PR DESCRIPTION
Version 2.0's headless flow treats Microsoft's one-time-code page like an approval challenge, so Google Authenticator users wait until authentication times out.

This change adds three setup choices: device approval/number matching, headless terminal code entry, and visible browser interaction. Explicit headless auth detects Microsoft's OTP field, prompts for a 6-8 digit code, submits it without logging the value, and continues the existing verified-session flow. Automatic MCP auth cannot safely read from protocol stdin, so it exits immediately with an instruction to run the auth CLI instead of recording a failed-MFA cooldown.

It also restores the existing `headless` configuration and `D2L_HEADLESS` override so the selected behavior reaches Chromium.

Validation:

- `npm run build`
- `npm run test:run -- tests/auth/purdue-sso-mfa.test.ts tests/auth/suny-sso.test.ts tests/auth/headless-login-visibility.test.ts tests/auth/auth-runner.test.ts` (52 passed)
- Live Queen's University Google Authenticator flow reached the new headless terminal-code prompt; visible-browser Google Authenticator login completed and verified Brightspace home
- Full Windows run: 409 passed, 5 skipped, with the existing `session-key-stability.test.ts` lock race intermittently failing with `EPERM`; that test file passes independently

Closes #21
