### PR TITLE
feat: authenticate on the first tool call instead of a separate check_auth tool

### DIFF
--- a/LLMs.md
+++ b/LLMs.md
@@ -69,6 +69,14 @@ Claude Desktop and Cursor are auto-configured by the setup wizard. For any other
 
 Tell the user to fully quit and reopen their AI client so it picks up the new MCP server.
 
+## Auth
+
+There is no authentication step and no tool to check one. Call the tool that answers the user's question; if no valid session exists, the request signs in first and then proceeds. Never tell the user to authenticate before asking something, and never call a tool purely to establish a session.
+
+A sign-in that cannot be completed comes back as the tool's own error, naming the cause and what to do: a locked credential store, a paused MFA cooldown, an unsupported login page, a network outage. Relay that text. Only the cooldown and unsupported cases need the terminal command below.
+
+Concurrent tool calls on a cold session share one sign-in, so firing several tools at once is safe and produces a single MFA prompt.
+
 ## Re-auth
 
 Access tokens are re-minted from the stored session cookie without a browser. A headless browser restores encrypted state for silent SSO when required, then enters saved credentials if Microsoft needs a full login. Missed MFA pauses automatic browser authentication, including SSO redirects, for four hours to prevent repeated phone prompts. HTTP token renewal remains allowed; the explicit command below bypasses the browser cooldown. Forward the MFA number to the user as it appears and wait for phone approval. Clients may hide server logs, so a terminal is the reliable place to see the number. Network errors and locked native storage should be reported without retrying MFA.
@@ -96,6 +104,8 @@ Registered in `src/tools/index.ts`, schemas in `src/tools/schemas.ts`:
 | `download_file` | Download a file attachment (PDF, slides, etc.) to disk |
 | `get_assignment_files` | Read the files attached to an assignment (spec, rubric, starter workbook) and return their text |
 
+These twelve are the whole surface. An available-update notice, when there is one, rides along as a second text block on the first successful result.
+
 Quiz attempt counts are unavailable to students on the Purdue tenant: `/quizzes/{id}/attempts/` answers 403. Those quizzes carry `attemptsAvailable: false` with null counts rather than a fabricated zero.
 
 Assignments, quizzes, and due dates each carry a `url` field that deep-links into Brightspace. `get_assignments` also returns `gradeOnly` items for gradebook columns that match no assignment or quiz, such as a proctored exam. `get_upcoming_due_dates` reads `DueDate` from assignments and `DueDate ?? EndDate` from quizzes rather than the calendar feed.
@@ -115,7 +125,10 @@ src/
     get-*.ts                One file per tool
     download-file.ts        Binary download + file-type detection
   api/
-    client.ts               HTTP client wrapping the Valence/D2L API
+    client.ts               HTTP client wrapping the Valence/D2L API. lp()/le()
+                            leave the version as a {lp}/{le} placeholder that
+                            get()/getRaw() substitute, so discovery and sign-in
+                            happen on the first request rather than at startup
     version-discovery.ts    Resolves per-product API versions
     cache.ts                In-memory response cache
     rate-limiter.ts         Token-bucket limiter
@@ -182,6 +195,8 @@ Add a preset to `SCHOOL_PRESETS` in `src/setup.ts`. If the school uses a non-sta
 2. Add the input schema to `src/tools/schemas.ts`.
 3. Export it from `src/tools/index.ts`.
 4. Register it in `src/index.ts`.
+
+Build paths with `apiClient.lp()`, `le()`, or `leGlobal()` and nothing else. They return a template carrying a `{lp}`/`{le}` placeholder, which `get()` and `getRaw()` substitute after discovering the versions, so a new tool gets lazy discovery and sign-in without asking for them. A hand-written path with a literal version skips discovery and will break when the tenant moves.
 
 ## Release workflow
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ You still need to run `npx brightspace-mcp-server setup` first to save your cred
 
 ## Session Expired?
 
+There is nothing to log into first. Ask for your grades and the sign-in happens as part of that request, so the assistant never has to check whether you are authenticated before it can answer. Starting your AI client touches Brightspace not at all: a restart on its own will never set off an MFA prompt.
+
 Returning the next day normally requires no action. The server renews short-lived API tokens over HTTPS using the saved Brightspace session. If that session ends, a headless browser restores your saved Microsoft session and tries silent SSO. If Microsoft requires sign-in, your saved credentials are entered automatically and you complete MFA on your phone.
 
 Your school's policy controls when MFA is required. There is no local 24-hour cutoff, and the server no longer discards browser state after one hour. A network outage preserves the saved session and returns a temporary error.
@@ -136,6 +138,13 @@ However, mistakes do occur, so regularly, especially if you suspect you're on an
 ```bash
 npx clear-npx-cache
 ```
+
+## What's new in 2.1.0
+
+- Signing in is part of the first tool call. The separate `check_auth` tool is gone, and so is the step where the assistant had to ask about your login before it could answer anything.
+- Starting the server makes no network requests. API versions are discovered by the first request that needs them, and a tenant that is briefly unreachable no longer stops the server from starting.
+- Concurrent tool calls on a cold session share one sign-in instead of racing, so you get one MFA prompt rather than several.
+- Failed sign-ins now explain themselves in the tool's answer: a locked keychain, a paused MFA cooldown, or a network outage each say what to do.
 
 ## What's new in 2.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brightspace-mcp-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brightspace-mcp-server",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brightspace-mcp-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "mcpName": "io.github.rohanmuppa/brightspace",
   "description": "MCP server for Brightspace (D2L). Check grades, due dates, assignments, announcements, syllabus, rosters and more via Claude, ChatGPT, Cursor, Windsurf, or any MCP client.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/RohanMuppa/brightspace-mcp-server",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "brightspace-mcp-server",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,10 +42,26 @@ function isExpiredSessionRedirect(body: string, baseUrl: string): boolean {
 }
 
 /**
+ * Stand-ins for the discovered LP and LE versions.
+ *
+ * lp(), le(), and leGlobal() are synchronous path builders called from about
+ * forty places across the tools, but the versions they need come from a
+ * network request. Emitting a placeholder and substituting it inside get()
+ * and getRaw() keeps that request off the startup path without turning every
+ * one of those call sites async, and it means a newly added tool cannot
+ * forget to wait for discovery: the path it builds carries the requirement.
+ *
+ * Braces are used because D2L paths never contain them, so a substitution can
+ * never collide with a real path segment.
+ */
+const LP_VERSION = "{lp}";
+const LE_VERSION = "{le}";
+
+/**
  * D2L API client with authentication, caching, rate limiting, and version discovery.
  *
  * Key features:
- * - Auto-discovers LP/LE versions from /d2l/api/versions/
+ * - Auto-discovers LP/LE versions from /d2l/api/versions/ on the first request
  * - Supports both Bearer tokens and cookie-based auth (auto-detected via "cookie:" prefix)
  * - Client-side rate limiting using token bucket algorithm
  * - In-memory response caching with per-data-type TTLs
@@ -64,6 +80,8 @@ export class D2LApiClient {
   private readonly onAuthExpired?: () => Promise<boolean>;
   private readonly retryConfig: RetryConfig;
   private versions: ApiVersions | null = null;
+  /** Single in-flight discovery, so concurrent first requests share one fetch. */
+  private versionsInFlight: Promise<ApiVersions> | null = null;
 
   constructor(options: D2LApiClientOptions) {
     // HTTPS-only enforcement, on a parsed URL rather than a string prefix so
@@ -105,28 +123,69 @@ export class D2LApiClient {
   }
 
   /**
-   * Initialize the client by discovering API versions.
-   * Must be called before making API requests.
+   * Discover the API versions, joining a discovery already in flight.
+   *
+   * Called from get() and getRaw() rather than at startup, so the server
+   * answers tools/list without touching the network and a user who never
+   * calls a tool never pays for a request. Nothing needs to call this
+   * directly.
+   */
+  async ensureVersions(): Promise<ApiVersions> {
+    if (this.versions) return this.versions;
+
+    if (!this.versionsInFlight) {
+      // The latch is released by the flow that owns it, as it settles, so a
+      // failed discovery is never replayed: the request after a network blip
+      // starts a fresh fetch instead of inheriting the stale rejection.
+      const flow = discoverVersions(this.baseUrl, this.timeoutMs)
+        .then(versions => {
+          this.versions = versions;
+          log("INFO", `D2L API versions discovered: LP ${versions.lp}, LE ${versions.le}`);
+          return versions;
+        })
+        .finally(() => {
+          if (this.versionsInFlight === flow) this.versionsInFlight = null;
+        });
+      this.versionsInFlight = flow;
+    }
+
+    return this.versionsInFlight;
+  }
+
+  /**
+   * Discover API versions eagerly. Idempotent, and no longer required:
+   * requests discover on demand. Kept for callers that want the network
+   * failure up front rather than on the first tool call.
    */
   async initialize(): Promise<void> {
-    this.versions = await discoverVersions(this.baseUrl, this.timeoutMs);
-    log(
-      "INFO",
-      `D2L API versions discovered: LP ${this.versions.lp}, LE ${this.versions.le}`,
-    );
+    await this.ensureVersions();
   }
 
   /**
    * Get discovered API versions.
-   * @throws Error if initialize() hasn't been called yet
+   * @throws Error if no request has discovered them yet
    */
   get apiVersions(): ApiVersions {
     if (!this.versions) {
       throw new Error(
-        "API client not initialized. Call initialize() before accessing apiVersions.",
+        "API versions have not been discovered yet. They are fetched on the first request.",
       );
     }
     return this.versions;
+  }
+
+  /**
+   * Substitute the discovered versions into a path built by lp(), le(), or
+   * leGlobal(), discovering them first if no request has yet.
+   *
+   * A path that carries no placeholder is returned untouched and costs
+   * nothing: a bookmark page whose URL came back fully resolved from D2L
+   * does not trigger a discovery of its own.
+   */
+  private async resolvePath(path: string): Promise<string> {
+    if (!path.includes(LP_VERSION) && !path.includes(LE_VERSION)) return path;
+    const { lp, le } = await this.ensureVersions();
+    return path.split(LP_VERSION).join(lp).split(LE_VERSION).join(le);
   }
 
   /**
@@ -139,13 +198,22 @@ export class D2LApiClient {
    * @throws NetworkError on network/fetch failures
    */
   async get<T>(path: string, options?: { ttl?: number }): Promise<T> {
-    // Check cache first
+    // Checked before the path is resolved, and keyed by the path as the caller
+    // wrote it, so a cached read needs neither version discovery nor a token.
     if (options?.ttl && this.cache.has(path)) {
       log("DEBUG", `Cache hit: ${path}`);
       return this.cache.get(path) as T;
     }
 
-    return this.withAuthentication(path, token => this.makeRequest<T>(path, token, options));
+    const resolved = await this.resolvePath(path);
+    const data = await this.withAuthentication(resolved, token => this.makeRequest<T>(resolved, token));
+
+    if (options?.ttl) {
+      this.cache.set(path, data, options.ttl);
+      log("DEBUG", `Cached response for ${path} (TTL: ${options.ttl}ms)`);
+    }
+
+    return data;
   }
 
   /**
@@ -159,7 +227,8 @@ export class D2LApiClient {
    * @throws NetworkError on network/fetch failures
    */
   async getRaw(path: string): Promise<Response> {
-    return this.withAuthentication(path, token => this.makeRawRequest(path, token));
+    const resolved = await this.resolvePath(path);
+    return this.withAuthentication(resolved, token => this.makeRawRequest(resolved, token));
   }
 
   /** One HTTP refresh and at most one browser login per caller. */
@@ -235,7 +304,6 @@ export class D2LApiClient {
   private async makeRequest<T>(
     path: string,
     token: TokenData,
-    options?: { ttl?: number },
   ): Promise<T> {
     const url = `${this.baseUrl}${path}`;
     const headers = this.buildAuthHeaders(token);
@@ -298,11 +366,6 @@ export class D2LApiClient {
           path,
           `Expected JSON from ${path} but the body did not parse`,
         );
-      }
-
-      if (options?.ttl) {
-        this.cache.set(path, data, options.ttl);
-        log("DEBUG", `Cached response for ${path} (TTL: ${options.ttl}ms)`);
       }
 
       return data;
@@ -445,33 +508,34 @@ export class D2LApiClient {
 
   /**
    * Build path for LP (Learning Platform) API endpoints.
+   *
+   * The version is left as a placeholder and substituted by get() or getRaw()
+   * once it has been discovered. See LP_VERSION above.
+   *
    * @param path - Path within LP API (e.g., "/users/whoami")
-   * @returns Full versioned path (e.g., "/d2l/api/lp/1.56/users/whoami")
+   * @returns Versioned path template (e.g., "/d2l/api/lp/{lp}/users/whoami")
    */
   lp(path: string): string {
-    const { lp } = this.apiVersions;
-    return `/d2l/api/lp/${lp}${path}`;
+    return `/d2l/api/lp/${LP_VERSION}${path}`;
   }
 
   /**
    * Build path for LE (Learning Environment) API endpoints with orgUnitId.
    * @param orgUnitId - Organizational unit ID (course ID)
    * @param path - Path within LE API (e.g., "/content/root/")
-   * @returns Full versioned path (e.g., "/d2l/api/le/1.91/123456/content/root/")
+   * @returns Versioned path template (e.g., "/d2l/api/le/{le}/123456/content/root/")
    */
   le(orgUnitId: number, path: string): string {
-    const { le } = this.apiVersions;
-    return `/d2l/api/le/${le}/${orgUnitId}${path}`;
+    return `/d2l/api/le/${LE_VERSION}/${orgUnitId}${path}`;
   }
 
   /**
    * Build path for global LE (Learning Environment) API endpoints without orgUnitId.
    * @param path - Path within LE API (e.g., "/enrollments/myenrollments/")
-   * @returns Full versioned path (e.g., "/d2l/api/le/1.91/enrollments/myenrollments/")
+   * @returns Versioned path template (e.g., "/d2l/api/le/{le}/enrollments/myenrollments/")
    */
   leGlobal(path: string): string {
-    const { le } = this.apiVersions;
-    return `/d2l/api/le/${le}${path}`;
+    return `/d2l/api/le/${LE_VERSION}${path}`;
   }
 
   /**

--- a/src/auth/auth-runner.ts
+++ b/src/auth/auth-runner.ts
@@ -90,7 +90,17 @@ function forwardLines(
  * so both processes read the same account configuration and .env file.
  */
 export class AuthRunner {
-  private running = false;
+  /**
+   * The login this process already started, if one is still running.
+   *
+   * Every tool call funnels here the moment the saved session is gone, and a
+   * stdio MCP server serves tool calls concurrently. Without a latch, two cold
+   * calls both see no token and both spawn a login: two browsers racing the
+   * same cross-process lock, and at Purdue two Authenticator prompts on the
+   * user's phone for one request. Holding the in-flight Promise makes every
+   * caller await the same login and read the same outcome.
+   */
+  private inFlight: Promise<boolean> | null = null;
   private readonly scriptPath: string;
   private readonly timeoutMs: number;
   private readonly onProgress?: (line: string) => void;
@@ -104,113 +114,122 @@ export class AuthRunner {
   }
 
   /**
-   * Spawn the auth CLI and wait for it to complete.
-   * Returns true on success and throws a useful error on failure.
-   * Prevents concurrent attempts within this MCP process.
+   * Authenticate, joining the login this process already started if there is
+   * one. Returns true on success and throws a useful error on failure.
    */
   async run(): Promise<boolean> {
-    if (this.running) {
-      throw new AuthProcessError("busy", "Authentication already in progress. Complete the existing attempt, then retry.");
+    if (this.inFlight) {
+      log("DEBUG", "Joining the authentication already in flight");
+      return this.inFlight;
     }
 
-    this.running = true;
-    try {
-      log("INFO", "Auto-launching brightspace-auth...");
+    // The latch is released by the flow that owns it, as it settles, so a
+    // failed login is never replayed: the tool call after a declined MFA
+    // prompt starts a fresh attempt rather than inheriting the stale
+    // rejection. Ownership is checked because a caller could in principle
+    // clear the latch while this flow is still running.
+    const flow = this.spawnAuth().finally(() => {
+      if (this.inFlight === flow) this.inFlight = null;
+    });
+    this.inFlight = flow;
+    return flow;
+  }
 
-      return await new Promise<boolean>((resolve, reject) => {
-        const child = spawn(
-          process.execPath, // use the same Node binary
-          [this.scriptPath, "--automatic"],
-          {
-            cwd: process.cwd(),
-            env: { ...process.env },
-            stdio: ["ignore", "pipe", "pipe"],
-            detached: process.platform !== "win32",
-          },
-        );
+  /** One child process, start to finish. */
+  private async spawnAuth(): Promise<boolean> {
+    log("INFO", "Auto-launching brightspace-auth...");
 
-        let timedOut = false;
-        let settled = false;
-        let killTimer: ReturnType<typeof setTimeout> | undefined;
-        const kill = (signal: NodeJS.Signals) => {
-          try {
-            if (child.pid && process.platform === "win32") {
-              execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
-                stdio: "ignore", timeout: 5000,
-              });
-            } else if (child.pid) {
-              if (signal === "SIGKILL") {
-                try {
-                  for (const pid of descendantPids(child.pid)) {
-                    try { process.kill(pid, "SIGKILL"); } catch { /* Already exited. */ }
-                  }
-                } catch { /* Still terminate the owned process group if ps is unavailable. */ }
-              }
-              process.kill(-child.pid, signal);
-            } else child.kill(signal);
-          } catch {
-            // The child may already have exited between close and cleanup.
-          }
-        };
-        const onExit = () => kill("SIGTERM");
-        process.once("exit", onExit);
-        const finish = (error?: AuthProcessError) => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timer);
-          if (killTimer) clearTimeout(killTimer);
-          process.off("exit", onExit);
-          if (error) reject(error);
-          else resolve(true);
-        };
-        const timer = setTimeout(() => {
-          timedOut = true;
-          kill("SIGTERM");
-          killTimer = setTimeout(() => {
-            kill("SIGKILL");
-            finish(new AuthProcessError("timeout", "Authentication timed out. Run brightspace-auth to try again."));
-          }, KILL_GRACE_MS);
-        }, this.timeoutMs);
+    return await new Promise<boolean>((resolve, reject) => {
+      const child = spawn(
+        process.execPath, // use the same Node binary
+        [this.scriptPath, "--automatic"],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env },
+          stdio: ["ignore", "pipe", "pipe"],
+          detached: process.platform !== "win32",
+        },
+      );
 
-        forwardLines(child.stderr, (line) => {
-          log("INFO", line);
-          try { this.onProgress?.(line); } catch { /* Logging must not interrupt authentication. */ }
-        });
-        // Piped and drained rather than ignored: a full stdout pipe would
-        // block the child mid-login.
-        forwardLines(child.stdout, (line) => log("DEBUG", line));
-
-        child.on("error", (error) => {
-          if (settled) return;
-          log("ERROR", "Auto-auth process failed", error.message);
+      let timedOut = false;
+      let settled = false;
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      const kill = (signal: NodeJS.Signals) => {
+        try {
+          if (child.pid && process.platform === "win32") {
+            execFileSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+              stdio: "ignore", timeout: 5000,
+            });
+          } else if (child.pid) {
+            if (signal === "SIGKILL") {
+              try {
+                for (const pid of descendantPids(child.pid)) {
+                  try { process.kill(pid, "SIGKILL"); } catch { /* Already exited. */ }
+                }
+              } catch { /* Still terminate the owned process group if ps is unavailable. */ }
+            }
+            process.kill(-child.pid, signal);
+          } else child.kill(signal);
+        } catch {
+          // The child may already have exited between close and cleanup.
+        }
+      };
+      const onExit = () => kill("SIGTERM");
+      process.once("exit", onExit);
+      const finish = (error?: AuthProcessError) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (killTimer) clearTimeout(killTimer);
+        process.off("exit", onExit);
+        if (error) reject(error);
+        else resolve(true);
+      };
+      const timer = setTimeout(() => {
+        timedOut = true;
+        kill("SIGTERM");
+        killTimer = setTimeout(() => {
           kill("SIGKILL");
-          finish(new AuthProcessError("failed", "Could not start authentication. Run brightspace-auth for details."));
-        });
+          finish(new AuthProcessError("timeout", "Authentication timed out. Run brightspace-auth to try again."));
+        }, KILL_GRACE_MS);
+      }, this.timeoutMs);
 
-        child.on("close", (code) => {
-          if (settled) return;
-          if (timedOut) {
-            kill("SIGKILL");
-            finish(new AuthProcessError("timeout", "Authentication timed out. Run brightspace-auth to try again."));
-          } else if (code === 0) {
-            log("INFO", "Auto-auth completed successfully");
-            finish();
-          } else {
-            const failures: Record<number, [AuthFailureKind, string]> = {
-              2: ["busy", "Authentication already in progress in another process. Complete that attempt, then retry."],
-              3: ["cooldown", "Automatic MFA is paused after an unsuccessful attempt. Run brightspace-auth to retry immediately."],
-              4: ["unsupported", "This identity provider cannot complete headless authentication. See the authentication logs."],
-              5: ["secureStorage", "The native credential store is unavailable or locked. Unlock it and retry."],
-              6: ["transport", "Brightspace authentication is temporarily unavailable because of a network or server failure. Your saved session was preserved. Try again later."],
-            };
-            const [kind, message] = failures[code ?? -1] ?? ["failed", "Authentication failed. Run brightspace-auth to try again."];
-            kill("SIGKILL");
-            finish(new AuthProcessError(kind, message));
-          }
-        });
+      forwardLines(child.stderr, (line) => {
+        log("INFO", line);
+        try { this.onProgress?.(line); } catch { /* Logging must not interrupt authentication. */ }
       });
-    } finally {
-      this.running = false;
-    }
+      // Piped and drained rather than ignored: a full stdout pipe would
+      // block the child mid-login.
+      forwardLines(child.stdout, (line) => log("DEBUG", line));
+
+      child.on("error", (error) => {
+        if (settled) return;
+        log("ERROR", "Auto-auth process failed", error.message);
+        kill("SIGKILL");
+        finish(new AuthProcessError("failed", "Could not start authentication. Run brightspace-auth for details."));
+      });
+
+      child.on("close", (code) => {
+        if (settled) return;
+        if (timedOut) {
+          kill("SIGKILL");
+          finish(new AuthProcessError("timeout", "Authentication timed out. Run brightspace-auth to try again."));
+        } else if (code === 0) {
+          log("INFO", "Auto-auth completed successfully");
+          finish();
+        } else {
+          const failures: Record<number, [AuthFailureKind, string]> = {
+            2: ["busy", "Authentication already in progress in another process. Complete that attempt, then retry."],
+            3: ["cooldown", "Automatic MFA is paused after an unsuccessful attempt. Run brightspace-auth to retry immediately."],
+            4: ["unsupported", "This identity provider cannot complete headless authentication. See the authentication logs."],
+            5: ["secureStorage", "The native credential store is unavailable or locked. Unlock it and retry."],
+            6: ["transport", "Brightspace authentication is temporarily unavailable because of a network or server failure. Your saved session was preserved. Try again later."],
+          };
+          const [kind, message] = failures[code ?? -1] ?? ["failed", "Authentication failed. Run brightspace-auth to try again."];
+          kill("SIGKILL");
+          finish(new AuthProcessError(kind, message));
+        }
+      });
+    });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { enableStdoutGuard, log } from "./utils/logger.js";
 import { loadConfig } from "./utils/config.js";
 import { TokenManager, AuthRunner } from "./auth/index.js";
 import { D2LApiClient } from "./api/index.js";
-import { initUpdateChecker, getUpdateNotice } from "./utils/update-checker.js";
+import { initUpdateChecker } from "./utils/update-checker.js";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
@@ -102,78 +102,16 @@ if (subcommand === 'setup') {
         onAuthExpired: () => authRunner.run(),
       });
 
-      // Initialize API client (discover API versions)
-      try {
-        await apiClient.initialize();
-        log("INFO", "D2L API Client initialized");
-      } catch (error) {
-        log("ERROR", "Failed to initialize D2L API Client", error);
-        log("ERROR", "MCP server cannot start without API initialization. Exiting.");
-        process.exit(1);
-      }
+      // Nothing here reaches Brightspace. API versions are discovered by the
+      // first request that needs them, and the first request with no saved
+      // session authenticates on its own (see D2LApiClient.withAuthentication).
+      // A server that signed in at startup would open an MFA prompt on the
+      // user's phone every time their editor restarted, whether or not they
+      // ever asked about a course, and a tenant that was briefly unreachable
+      // would take the whole server down with it.
 
       // Start background update check (fire and forget)
       initUpdateChecker();
-
-      // Register check_auth tool (no input schema needed for zero-argument tool)
-      server.registerTool(
-        "check_auth",
-        {
-          title: "Check Authentication Status",
-          description:
-            "Check if you are authenticated with Brightspace. " +
-            "Run the brightspace-auth CLI first to authenticate. " +
-            "Use this when the user asks if they're logged in, if authentication is working, " +
-            "or when other tools return auth errors.",
-        },
-        async () => {
-          log("DEBUG", "check_auth tool called");
-
-          let token = await tokenManager.getToken();
-
-          if (!token) {
-            log("INFO", "check_auth: No valid token, attempting auto-reauthentication...");
-
-            const success = await authRunner.run();
-            if (success) {
-              token = await tokenManager.getToken();
-            }
-
-            if (!token) {
-              log("INFO", "check_auth: Auto-reauthentication failed or produced no valid token");
-
-              const content: Array<{ type: "text"; text: string }> = [
-                {
-                  type: "text",
-                  text: "Not authenticated. Auto-reauthentication was attempted but failed. " +
-                    "Please run `brightspace-auth` manually in your terminal to log in. " +
-                    "Run setup to update your saved credentials, and check your internet connection.",
-                },
-              ];
-              const notice = getUpdateNotice();
-              if (notice) content.push({ type: "text", text: notice });
-              return { content };
-            }
-
-            log("INFO", "check_auth: Auto-reauthentication succeeded");
-          }
-
-          const expiresIn = Math.round((token.expiresAt - Date.now()) / 1000 / 60);
-          log("INFO", `check_auth: Token valid, expires in ~${expiresIn} minutes`);
-
-          const content: Array<{ type: "text"; text: string }> = [
-            {
-              type: "text",
-              text: `Authenticated with Brightspace. Token expires in ~${expiresIn} minutes. Source: ${token.source}.`,
-            },
-          ];
-          const notice = getUpdateNotice();
-          if (notice) content.push({ type: "text", text: notice });
-          return { content };
-        }
-      );
-
-      log("DEBUG", "check_auth tool registered");
 
       // Log active course filter config if any filter is set
       if (config.courseFilter.includeCourseIds || config.courseFilter.excludeCourseIds || !config.courseFilter.activeOnly) {
@@ -197,7 +135,7 @@ if (subcommand === 'setup') {
       registerGetRoster(server, apiClient);
       registerGetSyllabus(server, apiClient);
       registerGetDiscussions(server, apiClient);
-      log("DEBUG", "MCP tools registered (12 core tools, total 13 with check_auth)");
+      log("DEBUG", "MCP tools registered (12 tools)");
 
       // Connect stdio transport
       const transport = new StdioServerTransport();

--- a/src/tools/tool-helpers.ts
+++ b/src/tools/tool-helpers.ts
@@ -7,20 +7,32 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ZodError } from "zod";
 import { ApiError, RateLimitError, NetworkError } from "../api/index.js";
+import { TokenRefreshError } from "../api/errors.js";
+import { AuthProcessError, type AuthFailureKind } from "../auth/auth-runner.js";
 import { log } from "../utils/logger.js";
+import { getUpdateNotice } from "../utils/update-checker.js";
 
 /**
  * Wrap data as MCP-compatible tool result
+ *
+ * An available-update notice rides along on the first successful result that
+ * follows the startup check. This used to be check_auth's job; with
+ * authentication folded into the tools themselves there is no call the user
+ * reliably makes, so it attaches here. getUpdateNotice() clears itself, so the
+ * notice appears once per server run.
  */
 export function toolResponse(data: unknown): CallToolResult {
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(data, null, 2),
-      },
-    ],
-  };
+  const content: Array<{ type: "text"; text: string }> = [
+    {
+      type: "text",
+      text: JSON.stringify(data, null, 2),
+    },
+  ];
+
+  const notice = getUpdateNotice();
+  if (notice) content.push({ type: "text", text: notice });
+
+  return { content };
 }
 
 /**
@@ -39,6 +51,38 @@ export function errorResponse(message: string): CallToolResult {
 }
 
 /**
+ * What to tell the user for each way an automatic sign-in can fail.
+ *
+ * Authentication is the one failure mode where "an unexpected error occurred"
+ * costs the user a fix they could apply themselves, and it now happens inside
+ * an ordinary tool call rather than in a dedicated auth step. The text is
+ * keyed off AuthProcessError.kind, a closed set this package assigns itself;
+ * nothing is derived from the caught message, so a child process cannot put
+ * words in the response. The full error still goes to the log.
+ */
+const AUTH_FAILURE_GUIDANCE: Record<AuthFailureKind, string> = {
+  busy: "A sign-in is already running in another process. Let it finish, then try again.",
+  cooldown:
+    "Automatic sign-in is paused because an MFA prompt went unanswered. " +
+    "Run `brightspace-auth` in a terminal to retry now and see the number to enter.",
+  unsupported:
+    "This school's login page cannot be completed without a person at the keyboard. " +
+    "Run `brightspace-auth` in a terminal and sign in there.",
+  secureStorage:
+    "The operating system credential store is locked or unavailable, so the saved " +
+    "password could not be read. Unlock your keychain or keyring, then try again.",
+  transport:
+    "Brightspace could not be reached to sign in. The saved session was kept. " +
+    "Check your connection and try again in a few minutes.",
+  timeout:
+    "The sign-in did not finish in time, usually a missed MFA prompt. " +
+    "Run `brightspace-auth` in a terminal to complete it with the number visible.",
+  failed:
+    "The sign-in did not complete. Run `brightspace-auth` in a terminal to see why, " +
+    "or `brightspace-setup` if your saved school or username is wrong.",
+};
+
+/**
  * Sanitize errors for user-friendly messages
  *
  * SECURITY: Never include stack traces, raw API responses, or token values
@@ -46,6 +90,25 @@ export function errorResponse(message: string): CallToolResult {
 export function sanitizeError(error: unknown): CallToolResult {
   // Log full error to stderr for debugging (token redaction handled by logger)
   log("ERROR", "Tool error", error);
+
+  // Authentication runs inside the tool call now, so its failures surface
+  // here rather than from a dedicated auth tool. Checked first: the kind
+  // carries guidance that the generic branches below would throw away.
+  if (error instanceof AuthProcessError) {
+    return errorResponse(
+      `Could not sign in to Brightspace automatically. ${AUTH_FAILURE_GUIDANCE[error.kind]}`
+    );
+  }
+
+  // Checked before NetworkError, which it extends: a token service that is
+  // briefly down is not a dead internet connection, and the saved session
+  // survives it.
+  if (error instanceof TokenRefreshError) {
+    return errorResponse(
+      "Brightspace could not renew your session right now. Your saved login was kept. " +
+      "Try again in a few minutes."
+    );
+  }
 
   // Map to user-friendly messages
   if (error instanceof ApiError) {

--- a/tests/api/client.test.ts
+++ b/tests/api/client.test.ts
@@ -122,13 +122,13 @@ describe("D2LApiClient", () => {
       });
     });
 
-    it("should throw if accessed before initialize()", () => {
+    it("should throw if read before any request has discovered them", () => {
       const client = new D2LApiClient({
         baseUrl: "https://purdue.brightspace.com",
         tokenManager: mockTokenManager,
       });
 
-      expect(() => client.apiVersions).toThrow("not initialized");
+      expect(() => client.apiVersions).toThrow("have not been discovered yet");
     });
   });
 
@@ -528,69 +528,39 @@ describe("D2LApiClient", () => {
     });
   });
 
+  // The builders are pure string work that leaves the version as a
+  // placeholder, so they need neither a network round trip nor a discovered
+  // version. Substitution is a property of a request, and is covered against
+  // the URL actually fetched in tests/api/lazy-init.test.ts.
   describe("path helpers", () => {
-    it("should build LP paths correctly with lp()", async () => {
-      const client = new D2LApiClient({
+    const builderClient = () =>
+      new D2LApiClient({
         baseUrl: "https://purdue.brightspace.com",
         tokenManager: mockTokenManager,
       });
 
-      // Initialize
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => [
-          { ProductCode: "lp", LatestVersion: "1.56" },
-          { ProductCode: "le", LatestVersion: "1.91" },
-        ],
-      });
-      await client.initialize();
-
-      expect(client.lp("/users/whoami")).toBe("/d2l/api/lp/1.56/users/whoami");
+    it("should build LP paths with a version placeholder", () => {
+      expect(builderClient().lp("/users/whoami")).toBe("/d2l/api/lp/{lp}/users/whoami");
     });
 
-    it("should build LE paths correctly with le()", async () => {
-      const client = new D2LApiClient({
-        baseUrl: "https://purdue.brightspace.com",
-        tokenManager: mockTokenManager,
-      });
-
-      // Initialize
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => [
-          { ProductCode: "lp", LatestVersion: "1.56" },
-          { ProductCode: "le", LatestVersion: "1.91" },
-        ],
-      });
-      await client.initialize();
-
-      expect(client.le(123456, "/content/root/")).toBe(
-        "/d2l/api/le/1.91/123456/content/root/",
+    it("should build LE paths with a version placeholder", () => {
+      expect(builderClient().le(123456, "/content/root/")).toBe(
+        "/d2l/api/le/{le}/123456/content/root/",
       );
     });
 
-    it("should build global LE paths correctly with leGlobal()", async () => {
-      const client = new D2LApiClient({
-        baseUrl: "https://purdue.brightspace.com",
-        tokenManager: mockTokenManager,
-      });
-
-      // Initialize
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => [
-          { ProductCode: "lp", LatestVersion: "1.56" },
-          { ProductCode: "le", LatestVersion: "1.91" },
-        ],
-      });
-      await client.initialize();
-
-      expect(client.leGlobal("/enrollments/myenrollments/")).toBe(
-        "/d2l/api/le/1.91/enrollments/myenrollments/",
+    it("should build global LE paths with a version placeholder", () => {
+      expect(builderClient().leGlobal("/enrollments/myenrollments/")).toBe(
+        "/d2l/api/le/{le}/enrollments/myenrollments/",
       );
+    });
+
+    it("should not reach the network to build a path", () => {
+      const client = builderClient();
+      client.lp("/users/whoami");
+      client.le(123456, "/content/root/");
+      client.leGlobal("/enrollments/myenrollments/");
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/api/lazy-init.test.ts
+++ b/tests/api/lazy-init.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Brightspace MCP Server
+ * Copyright (c) 2026 Rohan Muppa. All rights reserved.
+ * Licensed under MIT — see LICENSE file for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { D2LApiClient } from "../../src/api/client.js";
+import { NetworkError } from "../../src/api/errors.js";
+import type { TokenManager } from "../../src/auth/token-manager.js";
+import type { TokenData } from "../../src/types/index.js";
+
+/**
+ * Nothing about starting the server should touch Brightspace. API versions are
+ * discovered, and a missing session is signed back in, by whichever request
+ * first needs them, so a user who never asks about a course never triggers a
+ * network call or an MFA prompt.
+ */
+
+const BASE_URL = "https://purdue.brightspace.com";
+const VERSIONS_URL = `${BASE_URL}/d2l/api/versions/`;
+
+const token = (accessToken = "test-token-12345678"): TokenData => ({
+  accessToken,
+  capturedAt: Date.now(),
+  expiresAt: Date.now() + 3_600_000,
+  source: "browser",
+});
+
+/** A token manager whose answers a test can change between calls. */
+function tokenManagerReturning(...answers: Array<TokenData | null>): TokenManager {
+  const queue = [...answers];
+  return {
+    async getToken() {
+      return queue.length > 1 ? queue.shift()! : queue[0] ?? null;
+    },
+  } as unknown as TokenManager;
+}
+
+const versionsBody = [
+  { ProductCode: "lp", LatestVersion: "1.56" },
+  { ProductCode: "le", LatestVersion: "1.91" },
+];
+
+const versionsResponse = () => ({ ok: true, status: 200, json: async () => versionsBody });
+
+const jsonResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  headers: new Headers({ "content-type": "application/json" }),
+  json: async () => body,
+  text: async () => JSON.stringify(body),
+});
+
+const binaryResponse = () => ({
+  ok: true,
+  status: 200,
+  headers: new Headers({ "content-type": "application/pdf" }),
+});
+
+describe("lazy initialization", () => {
+  let fetched: string[];
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof global.fetch;
+
+  /** Answer version discovery, and hand every other URL the same payload. */
+  function routeFetch(payload: unknown = { ok: true }) {
+    mockFetch.mockImplementation(async (url: string) => {
+      fetched.push(url);
+      return url === VERSIONS_URL ? versionsResponse() : jsonResponse(payload);
+    });
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    fetched = [];
+    mockFetch = vi.fn();
+    global.fetch = mockFetch as unknown as typeof global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("reaches the network for nothing when the client is constructed", () => {
+    new D2LApiClient({ baseUrl: BASE_URL, tokenManager: tokenManagerReturning(token()) });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("discovers versions on the first request and substitutes them into the path", async () => {
+    routeFetch();
+    const client = new D2LApiClient({ baseUrl: BASE_URL, tokenManager: tokenManagerReturning(token()) });
+
+    await client.get(client.lp("/users/whoami"));
+
+    expect(fetched).toEqual([VERSIONS_URL, `${BASE_URL}/d2l/api/lp/1.56/users/whoami`]);
+    expect(client.apiVersions).toEqual({ lp: "1.56", le: "1.91" });
+  });
+
+  it("substitutes the LE version into a download path too", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      fetched.push(url);
+      return url === VERSIONS_URL ? versionsResponse() : binaryResponse();
+    });
+    const client = new D2LApiClient({ baseUrl: BASE_URL, tokenManager: tokenManagerReturning(token()) });
+
+    await client.getRaw(client.le(123456, "/content/topics/789/file"));
+
+    expect(fetched).toEqual([
+      VERSIONS_URL,
+      `${BASE_URL}/d2l/api/le/1.91/123456/content/topics/789/file`,
+    ]);
+  });
+
+  it("discovers once for concurrent first requests", async () => {
+    routeFetch();
+    const client = new D2LApiClient({ baseUrl: BASE_URL, tokenManager: tokenManagerReturning(token()) });
+
+    await Promise.all([
+      client.get(client.lp("/users/whoami")),
+      client.get(client.leGlobal("/enrollments/myenrollments/")),
+      client.get(client.le(42, "/grades/")),
+    ]);
+
+    expect(fetched.filter(url => url === VERSIONS_URL)).toHaveLength(1);
+    expect(fetched).toHaveLength(4);
+  });
+
+  it("discovers once across later requests", async () => {
+    routeFetch();
+    const client = new D2LApiClient({ baseUrl: BASE_URL, tokenManager: tokenManagerReturning(token()) });
+
+    await client.get(client.lp("/users/whoami"));
+    await client.get(client.le(42, "/grades/"));
+
+    expect(fetched.filter(url => url === VERSIONS_URL)).toHaveLength(1);
+  });
+
+  it("retries a failed discovery instead of replaying the rejection", async () => {
+    const client = new D2LApiClient({ baseUrl: BASE_URL, tokenManager: tokenManagerReturning(token()) });
+    mockFetch.mockRejectedValueOnce(new Error("getaddrinfo ENOTFOUND"));
+
+    await expect(client.get(client.lp("/users/whoami"))).rejects.toThrow(NetworkError);
+
+    routeFetch({ FirstName: "Elliot" });
+    await expect(client.get(client.lp("/users/whoami"))).resolves.toEqual({ FirstName: "Elliot" });
+  });
+
+  it("serves a cached response without discovering versions or reading a token", async () => {
+    routeFetch({ cached: true });
+    const tokenManager = tokenManagerReturning(token());
+    const getToken = vi.spyOn(tokenManager, "getToken");
+    const client = new D2LApiClient({ baseUrl: BASE_URL, tokenManager });
+    const path = client.le(42, "/grades/");
+
+    await client.get(path, { ttl: 60_000 });
+    const callsAfterFirst = mockFetch.mock.calls.length;
+    const tokenReadsAfterFirst = getToken.mock.calls.length;
+
+    await expect(client.get(path, { ttl: 60_000 })).resolves.toEqual({ cached: true });
+
+    expect(mockFetch.mock.calls).toHaveLength(callsAfterFirst);
+    expect(getToken.mock.calls).toHaveLength(tokenReadsAfterFirst);
+  });
+
+  it("skips discovery for a path that carries no version placeholder", async () => {
+    routeFetch();
+    const client = new D2LApiClient({ baseUrl: BASE_URL, tokenManager: tokenManagerReturning(token()) });
+
+    // D2L hands back fully-resolved next-page URLs, which paginate.ts passes
+    // straight through. Those must not provoke a discovery of their own.
+    await client.get("/d2l/api/le/1.91/classlist/paged/?bookmark=abc");
+
+    expect(fetched).toEqual([`${BASE_URL}/d2l/api/le/1.91/classlist/paged/?bookmark=abc`]);
+  });
+
+  it("signs in on the first request when there is no saved session", async () => {
+    routeFetch({ Items: [] });
+    const onAuthExpired = vi.fn(async () => true);
+    // No token until the sign-in has run, exactly as a cold start looks.
+    const client = new D2LApiClient({
+      baseUrl: BASE_URL,
+      tokenManager: tokenManagerReturning(null, token("fresh-token-12345678")),
+      onAuthExpired,
+    });
+
+    await expect(client.get(client.lp("/users/whoami"))).resolves.toEqual({ Items: [] });
+
+    expect(onAuthExpired).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls.at(-1) as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer fresh-token-12345678");
+  });
+
+  it("reports the sign-in failure rather than a bare 401 when it cannot authenticate", async () => {
+    routeFetch();
+    const client = new D2LApiClient({
+      baseUrl: BASE_URL,
+      tokenManager: tokenManagerReturning(null),
+      onAuthExpired: async () => {
+        throw new Error("MFA was not approved");
+      },
+    });
+
+    await expect(client.get(client.lp("/users/whoami"))).rejects.toThrow("MFA was not approved");
+    // The sign-in failed before the request went out, so only discovery ran.
+    expect(fetched).toEqual([VERSIONS_URL]);
+  });
+});

--- a/tests/auth/auth-runner.test.ts
+++ b/tests/auth/auth-runner.test.ts
@@ -46,13 +46,40 @@ describe("AuthRunner", () => {
     expect(progress.mock.calls).toEqual([["MFA number: 42"], ["Waiting for approval"]]);
   });
 
-  it("returns a useful busy failure without starting a second child", async () => {
+  it("joins the login already in flight instead of spawning a second child", async () => {
     const runner = new AuthRunner();
     const first = runner.run();
-    await expect(runner.run()).rejects.toMatchObject({ kind: "busy" });
+    const second = runner.run();
+
     expect(spawn).toHaveBeenCalledTimes(1);
     child.emit("close", 0);
-    await first;
+
+    expect(await first).toBe(true);
+    expect(await second).toBe(true);
+  });
+
+  it("hands the same failure to every caller that joined", async () => {
+    const runner = new AuthRunner();
+    const first = expect(runner.run()).rejects.toMatchObject({ kind: "cooldown" });
+    const second = expect(runner.run()).rejects.toMatchObject({ kind: "cooldown" });
+    child.emit("close", 3);
+    await Promise.all([first, second]);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a fresh login after a failed one rather than replaying it", async () => {
+    const runner = new AuthRunner();
+    const failed = expect(runner.run()).rejects.toMatchObject({ kind: "failed" });
+    child.emit("close", 1);
+    await failed;
+
+    child = mockChild();
+    vi.mocked(spawn).mockReturnValue(child as never);
+    const retry = runner.run();
+    child.emit("close", 0);
+
+    expect(await retry).toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(2);
   });
 
   it.each([[2, "busy"], [3, "cooldown"], [4, "unsupported"], [5, "secureStorage"], [6, "transport"], [1, "failed"]])(

--- a/tests/tools/tool-helpers.test.ts
+++ b/tests/tools/tool-helpers.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Brightspace MCP Server
+ * Copyright (c) 2026 Rohan Muppa. All rights reserved.
+ * Licensed under MIT — see LICENSE file for details.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProcessError, type AuthFailureKind } from "../../src/auth/auth-runner.js";
+import { ApiError, NetworkError, RateLimitError, TokenRefreshError } from "../../src/api/errors.js";
+
+vi.mock("../../src/utils/logger.js", () => ({ log: vi.fn() }));
+vi.mock("../../src/utils/update-checker.js", () => ({ getUpdateNotice: vi.fn(() => null) }));
+
+const { getUpdateNotice } = await import("../../src/utils/update-checker.js");
+const { sanitizeError, toolResponse, errorResponse } = await import("../../src/tools/tool-helpers.js");
+
+const textOf = (result: { content: Array<{ type: string; text?: string }> }) =>
+  result.content.map(part => part.text ?? "").join("\n");
+
+describe("toolResponse", () => {
+  beforeEach(() => {
+    vi.mocked(getUpdateNotice).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the payload as pretty JSON", () => {
+    expect(toolResponse({ courses: [1, 2] }).content).toEqual([
+      { type: "text", text: '{\n  "courses": [\n    1,\n    2\n  ]\n}' },
+    ]);
+  });
+
+  // check_auth used to carry this. With authentication folded into the tools
+  // there is no call the user reliably makes, so an available update has to
+  // ride an ordinary result or it would never be seen.
+  it("appends an available-update notice as a second block", () => {
+    vi.mocked(getUpdateNotice).mockReturnValue("Update available: v2.0.0 to v2.1.0.");
+
+    const result = toolResponse({ ok: true });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[1]).toEqual({
+      type: "text",
+      text: "Update available: v2.0.0 to v2.1.0.",
+    });
+  });
+
+  it("leaves the result alone when there is no notice", () => {
+    expect(toolResponse({ ok: true }).content).toHaveLength(1);
+  });
+});
+
+describe("sanitizeError", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Authentication now fails inside an ordinary tool call, so every kind has
+  // to arrive as advice the user can act on rather than as "an unexpected
+  // error occurred", which is where all of these used to land.
+  const expectedGuidance: Array<[AuthFailureKind, string]> = [
+    ["busy", "already running in another process"],
+    ["cooldown", "MFA prompt went unanswered"],
+    ["unsupported", "cannot be completed without a person at the keyboard"],
+    ["secureStorage", "credential store is locked"],
+    ["transport", "could not be reached to sign in"],
+    ["timeout", "did not finish in time"],
+    ["failed", "did not complete"],
+  ];
+
+  it.each(expectedGuidance)("explains a %s sign-in failure", (kind, expected) => {
+    const result = sanitizeError(new AuthProcessError(kind, "internal detail"));
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain(expected);
+  });
+
+  it("never repeats the raw failure text back to the caller", () => {
+    const result = sanitizeError(
+      new AuthProcessError("failed", "chromium crashed at /home/elliot/.cache/ms-playwright")
+    );
+
+    expect(textOf(result)).not.toContain("ms-playwright");
+    expect(textOf(result)).not.toContain("/home/elliot");
+  });
+
+  // TokenRefreshError extends NetworkError, and the generic network message
+  // would tell the user to check a connection that is fine while hiding the
+  // part that matters: the saved login survived.
+  it("distinguishes a token-service outage from a dead connection", () => {
+    const result = sanitizeError(new TokenRefreshError("token service request failed"));
+
+    expect(textOf(result)).toContain("saved login was kept");
+    expect(textOf(result)).not.toContain("Check your internet connection");
+  });
+
+  it("still maps the HTTP and input failures it always did", () => {
+    expect(textOf(sanitizeError(new ApiError(404, "/x", "nope")))).toContain("Resource not found");
+    expect(textOf(sanitizeError(new ApiError(403, "/x", "nope")))).toContain("Access denied");
+    expect(textOf(sanitizeError(new RateLimitError("/x", 30)))).toContain("Rate limited");
+    expect(textOf(sanitizeError(new NetworkError("socket hang up")))).toContain(
+      "Check your internet connection"
+    );
+    expect(textOf(sanitizeError(new Error("something else")))).toContain("unexpected error");
+  });
+
+  it("does not attach an update notice to an error", () => {
+    vi.mocked(getUpdateNotice).mockReturnValue("Update available: v2.0.0 to v2.1.0.");
+
+    expect(errorResponse("nope").content).toHaveLength(1);
+    expect(getUpdateNotice).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What this changes

Signing in was its own tool. `check_auth` read the saved token, launched a login if there was none, and reported back. That put the decision in the assistant's hands: it had to know to call `check_auth` first, and a user whose session had lapsed got "run brightspace-auth" instead of their grades. Startup was eager in the same way. The server discovered API versions before connecting its transport and `process.exit(1)`'d if the tenant did not answer, so restarting an editor during a Brightspace outage left no server at all.

After this, authentication is part of whatever request needs it. Ask for grades, and the sign-in happens inside `get_my_grades`. There is nothing to call first.

The shape is borrowed from `google-tools-mcp`, which does the same thing for Google OAuth in `dist/clients.js`: a latched `ensureAuth()` every client getter funnels through, and a closed guidance table so an auth failure explains itself instead of surfacing as a generic error.

## Three pieces

**Version discovery moved into the request.** `lp()`, `le()`, and `leGlobal()` now leave the version as a `{lp}`/`{le}` placeholder rather than reading a discovered value. `get()` and `getRaw()` substitute it after a latched `ensureVersions()`. The alternative was making forty call sites `await` a path builder; this way a newly added tool gets lazy discovery for free and cannot forget to wait for it. The cache is checked before resolution and still keyed by the path as written, so a cached read needs neither a version nor a token. A path with no placeholder (a fully-resolved `Next` URL from D2L) skips discovery entirely.

**`AuthRunner.run()` latches instead of refusing.** It held a `running` boolean and threw `kind: "busy"` at the second caller. A stdio server serves tool calls concurrently, so two cold calls both saw no token and one of them just failed. Now they share the in-flight Promise: one child process, one cross-process lock, one Authenticator prompt on the user's phone. The latch is released as the flow settles, so a declined MFA is retried on the next call rather than replayed.

**`check_auth` is gone, and auth failures now say what to do.** `AuthRunner` throws `AuthProcessError` with a `kind`, and that used to escape `sanitizeError` into "An unexpected error occurred" — the least useful possible answer for a locked keychain. `sanitizeError` maps `kind` through a closed guidance table (nothing derived from the caught text, so a child process cannot put words in the response) and separates `TokenRefreshError` from `NetworkError`, which it extends, because "check your internet connection" is wrong advice when the connection is fine and the saved session survived. The npm update notice `check_auth` used to carry now rides the first successful tool result.

`initialize()` is kept, idempotent, for anyone who wants the network failure up front.

## Behavior changes worth flagging

- **`check_auth` is removed.** Twelve tools instead of thirteen. A client whose saved prompt names `check_auth` will not find it. That is the point of the change, but it is a visible removal.
- **The server starts even when Brightspace is unreachable or nothing is configured.** The failure now arrives on the first tool call, with a message, instead of as a dead server at launch.

## Testing

`npm run build` clean. Full suite: 430 passing.

New `tests/api/lazy-init.test.ts` covers construction reaching the network for nothing, discovery on first request with the placeholder substituted into the URL actually fetched, one discovery across concurrent and sequential requests, a failed discovery retried rather than replayed, a cached read that reads neither version nor token, a non-placeholder path skipping discovery, and a cold request signing in and then sending `Bearer` with the fresh token.

New `tests/tools/tool-helpers.test.ts` covers every `AuthFailureKind` producing actionable text, the raw failure text never being echoed back, `TokenRefreshError` not being mistaken for a dead connection, and the update notice attaching to results but not errors.

`tests/auth/auth-runner.test.ts` swaps the busy-failure test for three: concurrent callers share one child, all joiners get the same failure, and a fresh login starts after a failed one.

Also booted the built server over stdio with no config present: it comes up, makes no network request, and lists 12 tools.

Two tests fail on my Windows machine (`auth-lock`, `session-key-stability`) — they spawn real Node processes and hit EBUSY / the 5s timeout. Both fail identically on unmodified `main` here, so they are environmental. CI should be green.

## Version

Bumped to 2.1.0 in `package.json`, `server.json`, and the lockfile, per the release note in LLMs.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
